### PR TITLE
Fixes wrong behavior of SortArrow

### DIFF
--- a/lib/data_table_2.dart
+++ b/lib/data_table_2.dart
@@ -725,7 +725,7 @@ class _SortArrow extends StatefulWidget {
   final Duration duration;
 
   @override
-  _SortArrowState createState() => _SortArrowState();
+  _SortArrowState createState() => _SortArrowState(up);
 }
 
 class _SortArrowState extends State<_SortArrow> with TickerProviderStateMixin {
@@ -738,6 +738,10 @@ class _SortArrowState extends State<_SortArrow> with TickerProviderStateMixin {
 
   bool? _up;
 
+  _SortArrowState(bool? up) {
+    _up = up;
+  }
+  
   static final Animatable<double> _turnTween =
       Tween<double>(begin: 0.0, end: math.pi)
           .chain(CurveTween(curve: Curves.easeIn));


### PR DESCRIPTION
Fixes wrong behavior of SortArrow when the DataTable2 should be displayed with a initialized sorted column (without the user clicking on the header).