### PR TITLE
WIP More taps

### DIFF
--- a/lib/data_table_2.dart
+++ b/lib/data_table_2.dart
@@ -324,7 +324,11 @@ class DataTable2 extends DataTable {
     required bool numeric,
     required bool placeholder,
     required bool showEditIcon,
-    required VoidCallback? onTap,
+    required GestureTapCallback? onTap,
+    required GestureTapCallback? onDoubleTap,
+    required GestureLongPressCallback? onLongPress,
+    required GestureTapDownCallback? onTapDown,
+    required GestureTapCancelCallback? onTapCancel,
     required VoidCallback? onRowTap,
     required VoidCallback? onRowSecondaryTap,
     required GestureTapDownCallback? onRowSecondaryTapDown,
@@ -361,11 +365,19 @@ class DataTable2 extends DataTable {
         child: DropdownButtonHideUnderline(child: label),
       ),
     );
-    if (onTap != null) {
+    if (onTap != null ||
+        onDoubleTap != null ||
+        onLongPress != null ||
+        onTapDown != null ||
+        onTapCancel != null) {
       label = InkWell(
         onTap: onTap,
-        child: label,
+        onDoubleTap: onDoubleTap,
+        onLongPress: onLongPress,
+        onTapDown: onTapDown,
+        onTapCancel: onTapCancel,
         overlayColor: overlayColor,
+        child: label,
       );
     } else if (onSelectChanged != null) {
       label = GestureDetector(
@@ -630,6 +642,10 @@ class DataTable2 extends DataTable {
             placeholder: cell.placeholder,
             showEditIcon: cell.showEditIcon,
             onTap: cell.onTap,
+            onDoubleTap: cell.onDoubleTap,
+            onLongPress: cell.onLongPress,
+            onTapDown: cell.onTapDown,
+            onTapCancel: cell.onTapCancel,
             onRowTap: row is DataRow2 ? row.onTap : null,
             onRowSecondaryTap: row is DataRow2 ? row.onSecondaryTap : null,
             onRowSecondaryTapDown:

--- a/test/data_table_2_data_column_2_test.dart
+++ b/test/data_table_2_data_column_2_test.dart
@@ -57,6 +57,18 @@ void main() {
                 onTap: () {
                   log.add('cell-tap: ${dessert.calories}');
                 },
+                onDoubleTap: () {
+                  log.add('cell-doubleTap: ${dessert.calories}');
+                },
+                onLongPress: () {
+                  log.add('cell-longPress: ${dessert.calories}');
+                },
+                onTapCancel: () {
+                  log.add('cell-tapCancel: ${dessert.calories}');
+                },
+                onTapDown: (TapDownDetails details) {
+                  log.add('cell-tapDown: ${dessert.calories}');
+                },
               ),
             ],
           );
@@ -99,8 +111,52 @@ void main() {
     await tester.pumpAndSettle(const Duration(milliseconds: 200));
 
     await tester.tap(find.text('375'));
+    // Wait 500ms to get tap registered instead of double tap
+    await tester.pump(const Duration(milliseconds: 500));
 
-    expect(log, <String>['cell-tap: 375']);
+    expect(log, <String>['cell-tapDown: 375', 'cell-tap: 375']);
+    log.clear();
+
+    await tester.tap(find.text('375'));
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.tap(find.text('375'));
+
+    expect(log, <String>['cell-doubleTap: 375']);
+    log.clear();
+
+    await tester.longPress(find.text('375'));
+    // The tap down is triggered on gesture down.
+    // Then, the cancel is triggered when the gesture arena
+    // recognizes that the long press overrides the tap event
+    // so it triggers a tap cancel, followed by the long press.
+    expect(log, <String>[
+      'cell-tapDown: 375',
+      'cell-tapCancel: 375',
+      'cell-longPress: 375'
+    ]);
+    log.clear();
+
+    TestGesture gesture = await tester.startGesture(
+      tester.getRect(find.text('375')).center,
+    );
+    await tester.pump(const Duration(milliseconds: 100));
+    // onTapDown callback is registered.
+    expect(log, equals(<String>['cell-tapDown: 375']));
+    await gesture.up();
+
+    await tester.pump(const Duration(seconds: 1));
+    // onTap callback is registered after the gesture is removed.
+    expect(log, equals(<String>['cell-tapDown: 375', 'cell-tap: 375']));
+    log.clear();
+
+    // dragging off the bounds of the cell calls the cancel callback
+    gesture =
+        await tester.startGesture(tester.getRect(find.text('375')).center);
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.moveBy(const Offset(0.0, 200.0));
+    await gesture.cancel();
+    expect(log, equals(<String>['cell-tapDown: 375', 'cell-tapCancel: 375']));
+
     log.clear();
 
     await tester.tap(find.byType(Checkbox).last);

--- a/test/data_table_2_test.dart
+++ b/test/data_table_2_test.dart
@@ -57,6 +57,18 @@ void main() {
                 onTap: () {
                   log.add('cell-tap: ${dessert.calories}');
                 },
+                onDoubleTap: () {
+                  log.add('cell-doubleTap: ${dessert.calories}');
+                },
+                onLongPress: () {
+                  log.add('cell-longPress: ${dessert.calories}');
+                },
+                onTapCancel: () {
+                  log.add('cell-tapCancel: ${dessert.calories}');
+                },
+                onTapDown: (TapDownDetails details) {
+                  log.add('cell-tapDown: ${dessert.calories}');
+                },
               ),
             ],
           );
@@ -99,8 +111,52 @@ void main() {
     await tester.pumpAndSettle(const Duration(milliseconds: 200));
 
     await tester.tap(find.text('375'));
+    // Wait 500ms to get tap registered instead of double tap
+    await tester.pump(const Duration(milliseconds: 500));
 
-    expect(log, <String>['cell-tap: 375']);
+    expect(log, <String>['cell-tapDown: 375', 'cell-tap: 375']);
+    log.clear();
+
+    await tester.tap(find.text('375'));
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.tap(find.text('375'));
+
+    expect(log, <String>['cell-doubleTap: 375']);
+    log.clear();
+
+    await tester.longPress(find.text('375'));
+    // The tap down is triggered on gesture down.
+    // Then, the cancel is triggered when the gesture arena
+    // recognizes that the long press overrides the tap event
+    // so it triggers a tap cancel, followed by the long press.
+    expect(log, <String>[
+      'cell-tapDown: 375',
+      'cell-tapCancel: 375',
+      'cell-longPress: 375'
+    ]);
+    log.clear();
+
+    TestGesture gesture = await tester.startGesture(
+      tester.getRect(find.text('375')).center,
+    );
+    await tester.pump(const Duration(milliseconds: 100));
+    // onTapDown callback is registered.
+    expect(log, equals(<String>['cell-tapDown: 375']));
+    await gesture.up();
+
+    await tester.pump(const Duration(seconds: 1));
+    // onTap callback is registered after the gesture is removed.
+    expect(log, equals(<String>['cell-tapDown: 375', 'cell-tap: 375']));
+    log.clear();
+
+    // dragging off the bounds of the cell calls the cancel callback
+    gesture =
+        await tester.startGesture(tester.getRect(find.text('375')).center);
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.moveBy(const Offset(0.0, 200.0));
+    await gesture.cancel();
+    expect(log, equals(<String>['cell-tapDown: 375', 'cell-tapCancel: 375']));
+
     log.clear();
 
     await tester.tap(find.byType(Checkbox).last);


### PR DESCRIPTION
For https://github.com/maxim-saplin/data_table_2/issues/51

Adding support for `onDoubleTap`, `onLongPress`, `onTapCancel`, `onTapDown` to DataCell.

An identical implementation to https://github.com/flutter/flutter/pull/75393/files, which added the same set of functionalities to the Flutter's DataTable.