### PR TITLE
Resize column widget on PaginatedDataTable2

### DIFF
--- a/example/lib/screens/paginated_data_table2.dart
+++ b/example/lib/screens/paginated_data_table2.dart
@@ -66,49 +66,57 @@ class PaginatedDataTable2DemoState extends State<PaginatedDataTable2Demo> {
 
   List<DataColumn> get _columns {
     return [
-      DataColumn(
+      DataColumn2(
         label: const Text('Desert'),
+        resizeable: true,
         onSort: (columnIndex, ascending) =>
             sort<String>((d) => d.name, columnIndex, ascending),
       ),
-      DataColumn(
+      DataColumn2(
         label: const Text('Calories'),
+        resizeable: true,
         numeric: true,
         onSort: (columnIndex, ascending) =>
             sort<num>((d) => d.calories, columnIndex, ascending),
       ),
-      DataColumn(
+      DataColumn2(
         label: const Text('Fat (gm)'),
+        resizeable: true,
         numeric: true,
         onSort: (columnIndex, ascending) =>
             sort<num>((d) => d.fat, columnIndex, ascending),
       ),
-      DataColumn(
+      DataColumn2(
         label: const Text('Carbs (gm)'),
+        resizeable: true,
         numeric: true,
         onSort: (columnIndex, ascending) =>
             sort<num>((d) => d.carbs, columnIndex, ascending),
       ),
-      DataColumn(
+      DataColumn2(
         label: const Text('Protein (gm)'),
+        resizeable: true,
         numeric: true,
         onSort: (columnIndex, ascending) =>
             sort<num>((d) => d.protein, columnIndex, ascending),
       ),
-      DataColumn(
+      DataColumn2(
         label: const Text('Sodium (mg)'),
+        resizeable: true,
         numeric: true,
         onSort: (columnIndex, ascending) =>
             sort<num>((d) => d.sodium, columnIndex, ascending),
       ),
-      DataColumn(
+      DataColumn2(
         label: const Text('Calcium (%)'),
+        resizeable: true,
         numeric: true,
         onSort: (columnIndex, ascending) =>
             sort<num>((d) => d.calcium, columnIndex, ascending),
       ),
-      DataColumn(
+      DataColumn2(
         label: const Text('Iron (%)'),
+        resizeable: true,
         numeric: true,
         onSort: (columnIndex, ascending) =>
             sort<num>((d) => d.iron, columnIndex, ascending),

--- a/lib/src/data_table_2.dart
+++ b/lib/src/data_table_2.dart
@@ -329,10 +329,12 @@ class DataTable2 extends DataTable {
                 onColumnResized!(dc2, d.delta.dx);
               }
             },
-            feedback: const RotatedBox(
+            axis: Axis.horizontal,
+            childWhenDragging: const RotatedBox(
               quarterTurns: 1,
               child: Icon(Icons.vertical_align_center),
             ),
+            feedback: const SizedBox.shrink(),
             child: const Icon(Icons.drag_indicator),
           ),
         ],
@@ -691,6 +693,18 @@ class DataTable2 extends DataTable {
   List<double> _calculateDataColumnSizes(BoxConstraints constraints,
       double checkBoxWidth, double effectiveHorizontalMargin) {
     var totalColAvailableWidth = constraints.maxWidth;
+    double totalExtraWidth = 0;
+    double tFW = 0;
+    for (var c in columns) {
+      if (c is DataColumn2) {
+        totalColAvailableWidth += c.extraWidth;
+        totalExtraWidth += c.extraWidth;
+        if (c.fixedWidth != null) {
+          tFW += c.fixedWidth!;
+        }
+      }
+    }
+    totalFixedWidth = tFW;
     if (minWidth != null && totalColAvailableWidth < minWidth!) {
       totalColAvailableWidth = minWidth!;
     }
@@ -705,15 +719,9 @@ class DataTable2 extends DataTable {
             : effectiveHorizontalMargin);
     totalColAvailableWidth = totalColAvailableWidth - minColWidth;
 
-    var columnWidth = totalColAvailableWidth / columns.length;
+    var columnWidth =
+        (totalColAvailableWidth - totalExtraWidth) / columns.length;
     var totalColCalculatedWidth = 0.0;
-    totalFixedWidth = columns.fold<double>(
-        0.0,
-        (previousValue, element) =>
-            previousValue +
-            (element is DataColumn2 && element.fixedWidth != null
-                ? element.fixedWidth!
-                : 0.0));
     this.totalColAvailableWidth = totalColAvailableWidth;
     assert(totalFixedWidth < totalColAvailableWidth,
         "DataTable2, combined width of columns of fixed width is greater than availble parent width. Table will be clipped");

--- a/lib/src/paginated_data_table_2.dart
+++ b/lib/src/paginated_data_table_2.dart
@@ -644,6 +644,26 @@ class PaginatedDataTable2State extends State<PaginatedDataTable2> {
     );
   }
 
+  void _onColumnresized(DataColumn2 dc2, double delta) {
+    int idx = widget.columns.indexOf(dc2);
+    double ew = dc2.extraWidth + delta;
+    if (idx >= 0) {
+      DataColumn2 dcn = DataColumn2(
+        label: dc2.label,
+        fixedWidth: dc2.fixedWidth,
+        numeric: dc2.numeric,
+        onSort: dc2.onSort,
+        resizeable: dc2.resizeable,
+        extraWidth: (ew) > 0 ? ew : 0,
+        size: dc2.size,
+        tooltip: dc2.tooltip,
+      );
+      setState(() {
+        widget.columns[idx] = dcn;
+      });
+    }
+  }
+
   Widget _getTable(BoxConstraints constraints) {
     return Flexible(
       fit: widget.fit,
@@ -673,6 +693,7 @@ class PaginatedDataTable2State extends State<PaginatedDataTable2> {
           border: widget.border,
           smRatio: widget.smRatio,
           lmRatio: widget.lmRatio,
+          onColumnResized: _onColumnresized,
         ),
       ),
     );

--- a/lib/src/paginated_data_table_2.dart
+++ b/lib/src/paginated_data_table_2.dart
@@ -644,9 +644,10 @@ class PaginatedDataTable2State extends State<PaginatedDataTable2> {
     );
   }
 
-  void _onColumnresized(DataColumn2 dc2, double delta) {
+  void _onColumnResized(DataColumn2 dc2, double delta) {
     int idx = widget.columns.indexOf(dc2);
     double ew = dc2.extraWidth + delta;
+
     if (idx >= 0) {
       DataColumn2 dcn = DataColumn2(
         label: dc2.label,
@@ -693,7 +694,7 @@ class PaginatedDataTable2State extends State<PaginatedDataTable2> {
           border: widget.border,
           smRatio: widget.smRatio,
           lmRatio: widget.lmRatio,
-          onColumnResized: _onColumnresized,
+          onColumnResized: _onColumnResized,
         ),
       ),
     );


### PR DESCRIPTION
Widget to resize columns manually. It can be anabled by setting to true the `resizeable` variable in the `DataColumn2` constructor.
https://user-images.githubusercontent.com/5269947/169674825-17f5f538-7c22-417e-8b41-297605912657.mov