### PR TITLE
sortArrowIcon for PaginatedDataTable2 and AsyncPaginatedDataTable2

### DIFF
--- a/example/lib/screens/async_paginated_data_table2.dart
+++ b/example/lib/screens/async_paginated_data_table2.dart
@@ -207,6 +207,8 @@ class AsyncPaginatedDataTable2DemoState
           },
           sortColumnIndex: _sortColumnIndex,
           sortAscending: _sortAscending,
+          sortArrowIcon: Icons.keyboard_arrow_up,
+          sortArrowAnimationDuration: const Duration(milliseconds: 0),
           onSelectAll: (select) => select != null && select
               ? (getCurrentRouteOption(context) != selectAllPage
                   ? _dessertsDataSource!.selectAll()

--- a/example/lib/screens/paginated_data_table2.dart
+++ b/example/lib/screens/paginated_data_table2.dart
@@ -167,6 +167,9 @@ class PaginatedDataTable2DemoState extends State<PaginatedDataTable2Demo> {
         },
         sortColumnIndex: _sortColumnIndex,
         sortAscending: _sortAscending,
+        sortArrowIcon: Icons.keyboard_arrow_up, // custom arrow
+        sortArrowAnimationDuration:
+            const Duration(milliseconds: 0), // custom animation duration
         onSelectAll: _dessertsDataSource.selectAll,
         controller:
             getCurrentRouteOption(context) == custPager ? _controller : null,

--- a/lib/paginated_data_table_2.dart
+++ b/lib/paginated_data_table_2.dart
@@ -1,6 +1,7 @@
 // This file is a duplicate of data_table_2.dart and aimed
 // to avoid compliation issues when migrating to
 // newer version of the packae with lib exports and /src folder
+// TODO, remove with the next major version (2.4.0)
 @Deprecated('Use "package:data_table_2/data_table_2.dart" instead')
 library data_table_2_depricated;
 

--- a/lib/src/async_paginated_data_table_2.dart
+++ b/lib/src/async_paginated_data_table_2.dart
@@ -318,6 +318,8 @@ class AsyncPaginatedDataTable2 extends PaginatedDataTable2 {
       required super.columns,
       super.sortColumnIndex,
       super.sortAscending = true,
+      super.sortArrowAnimationDuration = const Duration(milliseconds: 150),
+      super.sortArrowIcon = Icons.arrow_upward,
       super.onSelectAll,
       super.dataRowHeight = kMinInteractiveDimension,
       super.headingRowColor,

--- a/lib/src/data_table_2.dart
+++ b/lib/src/data_table_2.dart
@@ -181,12 +181,12 @@ class DataTable2 extends DataTable {
   /// The default divider thickness.
   static const double _dividerThickness = 1.0;
 
-  /// When changin sorting direction arrow icon is the header is rotated clockwise.
+  /// When changing sort direction an arrow icon in the header is rotated clockwise.
   /// The value defines the duration of the rotation animation.
   /// If not set, the default animation duration is 150 ms.
   final Duration sortArrowAnimationDuration;
 
-  /// Icon to be displayed when sorting to a column is applied.
+  /// Icon to be displayed when sorting is applied to a column.
   /// If not set, the default icon is [Icons.arrow_upward]
   final IconData sortArrowIcon;
 

--- a/lib/src/paginated_data_table_2.dart
+++ b/lib/src/paginated_data_table_2.dart
@@ -164,6 +164,8 @@ class PaginatedDataTable2 extends StatefulWidget {
     required this.columns,
     this.sortColumnIndex,
     this.sortAscending = true,
+    this.sortArrowAnimationDuration = const Duration(milliseconds: 150),
+    this.sortArrowIcon = Icons.arrow_upward,
     this.onSelectAll,
     this.dataRowHeight = kMinInteractiveDimension,
     this.headingRowHeight = 56.0,
@@ -243,6 +245,15 @@ class PaginatedDataTable2 extends StatefulWidget {
   ///
   /// See [DataTable.sortAscending].
   final bool sortAscending;
+
+  /// When changin sorting direction arrow icon is the header is rotated clockwise.
+  /// The value defines the duration of the rotation animation.
+  /// If not set, the default animation duration is 150 ms.
+  final Duration sortArrowAnimationDuration;
+
+  /// Icon to be displayed when sorting to a column is applied.
+  /// If not set, the default icon is [Icons.arrow_upward]
+  final IconData sortArrowIcon;
 
   /// Invoked when the user selects or unselects every row, using the
   /// checkbox in the heading row.
@@ -654,6 +665,8 @@ class PaginatedDataTable2State extends State<PaginatedDataTable2> {
           columns: widget.columns,
           sortColumnIndex: widget.sortColumnIndex,
           sortAscending: widget.sortAscending,
+          sortArrowIcon: widget.sortArrowIcon,
+          sortArrowAnimationDuration: widget.sortArrowAnimationDuration,
           onSelectAll: widget.onSelectAll,
           // Make sure no decoration is set on the DataTable
           // from the theme, as its already wrapped in a Card.

--- a/lib/src/paginated_data_table_2.dart
+++ b/lib/src/paginated_data_table_2.dart
@@ -246,12 +246,12 @@ class PaginatedDataTable2 extends StatefulWidget {
   /// See [DataTable.sortAscending].
   final bool sortAscending;
 
-  /// When changin sorting direction arrow icon is the header is rotated clockwise.
+  /// When changing sort direction an arrow icon in the header is rotated clockwise.
   /// The value defines the duration of the rotation animation.
   /// If not set, the default animation duration is 150 ms.
   final Duration sortArrowAnimationDuration;
 
-  /// Icon to be displayed when sorting to a column is applied.
+  /// Icon to be displayed when sorting is applied to a column.
   /// If not set, the default icon is [Icons.arrow_upward]
   final IconData sortArrowIcon;
 

--- a/test/custom_features_test.dart
+++ b/test/custom_features_test.dart
@@ -737,6 +737,98 @@ void main() {
         i++;
       }
     });
+
+    // $ add sortArrowIcon test here
+    testWidgets('Custom sortArrowIcon test for PaginatedDataTable2',
+        (WidgetTester tester) async {
+      IconData iconForTest = Icons.keyboard_arrow_up;
+      var sortAscendingGlobal = true;
+      var currentColumnIndex = 0;
+      var trigger = StreamController();
+
+      // using 'columns' here for the fake async trigger
+      final triggerColumns = <DataColumn2>[
+        DataColumn2(
+            label: const Text('Name'),
+            tooltip: 'Name',
+            onSort: (int columnIndex, bool ascending) {
+              sortAscendingGlobal = !sortAscendingGlobal;
+              currentColumnIndex = columnIndex;
+
+              trigger.add(null);
+              // print(
+              //     'onSort() --> [column: $columnIndex, ascending: $ascending], sortAscendingGlobal: $sortAscendingGlobal');
+            }),
+        const DataColumn2(
+          label: Text('Calories'),
+          tooltip: 'Calories',
+          numeric: true,
+          //onSort: (int columnIndex, bool ascending) {},
+        ),
+        const DataColumn2(
+          label: Text('Carbs'),
+          tooltip: 'Carbs',
+          numeric: true,
+          //onSort: (int columnIndex, bool ascending) {},
+        ),
+      ];
+
+      Widget getStatefulWidget(
+          {IconData? sortArrowIcon, Duration? sortArrowAnimationDuration}) {
+        return StreamBuilder(
+            stream: trigger.stream,
+            builder: (c, s) {
+              return MaterialApp(
+                home: Material(
+                  child: buildPaginatedTable(
+                      sortAscending: sortAscendingGlobal,
+                      sortArrowIcon: sortArrowIcon,
+                      sortArrowAnimationDuration: sortArrowAnimationDuration,
+                      sortColumnIndex: currentColumnIndex,
+                      columns: triggerColumns),
+                ),
+              );
+            });
+      }
+
+      await tester.pumpWidget(getStatefulWidget(
+        sortArrowIcon: iconForTest,
+        sortArrowAnimationDuration: const Duration(milliseconds: 100),
+      ));
+
+      expect(find.byIcon(iconForTest), findsOneWidget);
+
+      // initial rotation before toggle
+      Transform transformOfArrow = tester.widget<Transform>(
+        find.widgetWithIcon(Transform, iconForTest).first,
+      );
+      expect(
+          transformOfArrow.transform.getRotation(), equals(Matrix3.identity()));
+
+      // tap column header to toggle sort to descending...
+      await tester.tap(find.text('Name'));
+      await tester.pump(const Duration(milliseconds: 95));
+
+      // rotation before sortArrowAnimationDuration
+      transformOfArrow = tester.widget<Transform>(
+        find.widgetWithIcon(Transform, iconForTest).first,
+      );
+      print(
+          'before sortArrowAnimationDuration: \n${transformOfArrow.transform.getRotation()}');
+      expect(transformOfArrow.transform.getRotation(),
+          isNot(Matrix3.rotationZ(math.pi)));
+
+      await tester.pump(const Duration(milliseconds: 105));
+
+      // rotation after sortArrowAnimationDuration
+      transformOfArrow = tester.widget<Transform>(
+        find.widgetWithIcon(Transform, iconForTest).first,
+      );
+      expect(transformOfArrow.transform.getRotation(),
+          equals(Matrix3.rotationZ(math.pi)));
+      print(
+          'after sortArrowAnimationDuration: \n${transformOfArrow.transform.getRotation()}');
+    });
   });
 
   group('AsyncPaginatedDataTable2', () {

--- a/test/custom_features_test.dart
+++ b/test/custom_features_test.dart
@@ -1264,6 +1264,7 @@ void main() {
       Transform transformOfArrow = tester.widget<Transform>(
         find.widgetWithIcon(Transform, iconForTest).first,
       );
+      //print('before tap: \n${transformOfArrow.transform.getRotation()}');
       expect(
           transformOfArrow.transform.getRotation(), equals(Matrix3.identity()));
 
@@ -1290,6 +1291,8 @@ void main() {
           equals(Matrix3.rotationZ(math.pi)));
       print(
           'after sortArrowAnimationDuration: \n${transformOfArrow.transform.getRotation()}');
+
+      tester.pumpAndSettle();
     });
 
     testWidgets('Default loading spinner is shown',

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -292,6 +292,8 @@ PaginatedDataTable2 buildPaginatedTable(
 PaginatedDataTable2 buildAsyncPaginatedTable(
     {int? sortColumnIndex,
     bool sortAscending = true,
+    IconData? sortArrowIcon,
+    Duration? sortArrowAnimationDuration,
     bool showPage = true,
     bool showGeneration = true,
     bool overrideSizes = false,
@@ -325,6 +327,9 @@ PaginatedDataTable2 buildAsyncPaginatedTable(
     header: showHeader ? const Text('Header') : null,
     sortColumnIndex: sortColumnIndex,
     sortAscending: sortAscending,
+    sortArrowIcon: sortArrowIcon ?? Icons.arrow_upward,
+    sortArrowAnimationDuration:
+        sortArrowAnimationDuration ?? const Duration(milliseconds: 150),
     onSelectAll: onSelectAll ?? (bool? value) {},
     columns: columns ?? testColumns,
     showFirstLastButtons: true,

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -234,6 +234,8 @@ class TestDataSource extends DataTableSource {
 PaginatedDataTable2 buildPaginatedTable(
     {int? sortColumnIndex,
     bool sortAscending = true,
+    IconData? sortArrowIcon,
+    Duration? sortArrowAnimationDuration,
     bool showPage = true,
     bool showGeneration = true,
     bool overrideSizes = false,
@@ -259,6 +261,9 @@ PaginatedDataTable2 buildPaginatedTable(
     header: showHeader ? const Text('Header') : null,
     sortColumnIndex: sortColumnIndex,
     sortAscending: sortAscending,
+    sortArrowIcon: sortArrowIcon ?? Icons.arrow_upward,
+    sortArrowAnimationDuration:
+        sortArrowAnimationDuration ?? const Duration(milliseconds: 150),
     onSelectAll: (bool? value) {},
     columns: columns ?? testColumns,
     showFirstLastButtons: true,


### PR DESCRIPTION
I have updated PaginatedDataTable2 and AsyncPaginatedDataTable2 with the new sortArrowIcon and sortArrowAnimationDuration parameters. It is done in 3 commits. The 2nd commit had an error in the testing that I was asking about but I fixed it in the 3rd commit. If I need to do anything else, just let me know.

Thanks.
