### PR TITLE
Fix issue with multiple scrollbars, use scrollbar theme from app's theme

### DIFF
--- a/lib/src/data_table_2.dart
+++ b/lib/src/data_table_2.dart
@@ -927,13 +927,24 @@ class DataTable2 extends DataTable {
                                   ))),
                     Flexible(
                         fit: FlexFit.tight,
-                        child: SingleChildScrollView(
+                        child: Scrollbar(
                             controller: coreVerticalController,
-                            scrollDirection: Axis.vertical,
-                            child: SingleChildScrollView(
-                                controller: coreHorizontalController,
-                                scrollDirection: Axis.horizontal,
-                                child: _addBottomMargin(coreTable))))
+                            child: ScrollConfiguration(
+                                behavior: ScrollConfiguration.of(context)
+                                    .copyWith(scrollbars: false),
+                                child: SingleChildScrollView(
+                                    controller: coreVerticalController,
+                                    scrollDirection: Axis.vertical,
+                                    child: ScrollConfiguration(
+                                        behavior:
+                                            ScrollConfiguration.of(context)
+                                                .copyWith(scrollbars: false),
+                                        child: SingleChildScrollView(
+                                            controller:
+                                                coreHorizontalController,
+                                            scrollDirection: Axis.horizontal,
+                                            child: _addBottomMargin(
+                                                coreTable)))))))
                   ]));
 
               fixedColumnAndCornerCol = fixedTopLeftCornerTable == null &&


### PR DESCRIPTION
1) Solves a bug that when scrolling all the way to the bottom of the table and the table is horizontally scrollable a double horizontal scrollbar appears.
2) Uses the scrollbar theme from the app itself, which means that the scrollbar theme can be customized through the app's theme.