### PR TITLE
add property to prevent onSelectChanged invocation on row tap

### DIFF
--- a/lib/src/data_table_2.dart
+++ b/lib/src/data_table_2.dart
@@ -125,6 +125,7 @@ class DataTable2 extends DataTable {
     this.bottomMargin,
     super.columnSpacing,
     super.showCheckboxColumn = true,
+    this.changeSelectedOnRowTap = true,
     super.showBottomBorder = false,
     super.dividerThickness,
     this.minWidth,
@@ -249,6 +250,10 @@ class DataTable2 extends DataTable {
   /// Note: to change background color of fixed data rows use [DataTable2.headingRowColor] and
   /// individual row colors of data rows provided via [rows]
   final Color? fixedCornerColor;
+
+  /// Determines if [DataRow2.onSelectChanged] is invoked when the row is tapped
+  /// If true, [DataRow2.onSelectChanged] will be invoked when the row is tapped
+  final bool changeSelectedOnRowTap;
 
   Widget _buildCheckbox(
       {required BuildContext context,
@@ -447,7 +452,7 @@ class DataTable2 extends DataTable {
             ? null
             : () {
                 onRowTap?.call();
-                onSelectChanged?.call();
+                if (changeSelectedOnRowTap) onSelectChanged?.call();
               },
         onDoubleTap: onRowDoubleTap,
         onLongPress: onRowLongPress,

--- a/test/data_table_2_test.dart
+++ b/test/data_table_2_test.dart
@@ -493,9 +493,14 @@ void main() {
       (WidgetTester tester) async {
     final List<String> log = <String>[];
 
-    Widget buildTable({int? sortColumnIndex, bool sortAscending = true}) {
+    Widget buildTable({
+      int? sortColumnIndex,
+      bool sortAscending = true,
+      changeSelectedOnRowTap = true,
+    }) {
       return DataTable2(
         sortColumnIndex: sortColumnIndex,
+        changeSelectedOnRowTap: changeSelectedOnRowTap,
         sortAscending: sortAscending,
         onSelectAll: (bool? value) {
           log.add('select-all: $value');
@@ -587,6 +592,21 @@ void main() {
 
     await tester.longPress(find.text('305'));
     expect(log, <String>['row-longPress: Cupcake']);
+    log.clear();
+
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: buildTable(
+          changeSelectedOnRowTap: false,
+        ),
+      ),
+    ));
+
+    await tester.tap(find.text('Cupcake'));
+    // Wait 500ms to get tap registered instead of double tap
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(log, <String>['row-tap: Cupcake']);
     log.clear();
   });
 


### PR DESCRIPTION
The original `DataTable` does not invoke `DataRow.onSelectChange` when the row's `Inkwell` is tapped. Right now, I am running into an issue where tapping an the row navigates to a details page. Upon returning from the details page, the row I tapped is selected when it shouldn't be. This suggested change gives the user the ability to disable `DataRow2.onSelectChanged` from being invoked when the row is tapped.