### PR TITLE
`onSelectChanged` is invoked when `onTap` is set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.3.7
+- Row tap events now do not bubble onSelectChanged() event handler, yet it still fires if there's a checkbox column and a checkbox is clicked (PR #133)
+
 ## 2.3.6
 -  Added sortArrowIcon and sortArrowAnimationDuration properties
 

--- a/README.md
+++ b/README.md
@@ -103,10 +103,12 @@ class DataTable2SimpleDemo extends StatelessWidget {
 ```
 If you're already using the standard widgets you can reference the package and add '2' to the names of stock widgets (making them **DataTable2** or **PaginatedDataTable2**) and that is it. 
 
-##  Know issues/limitations
+##  Know issues/limitations/caveats
 - Paginated tables always have 1 fixed row and no fixed columns, might be added soon
 - There's no capability to size data table cells to fit contents. Column width's adapt to available width (either to parent width or `minWidth`), data rows width are predefined by constructor params. Content that doesn't fit a cell gets clipped
 - There're no expanding/collapsing rows (drill-down scenarios), manually moving or resizing columns or rows, merging cells (i.e. HTML's colspan, rowspan)
 - When fixing left columns, hovering over rows doesn't highlight entire row (should there be any tap handlers standard behavior is hovering a row changes it background)
  - With fixed top rows and left columns hovering over actionable data rows their highlighted background can be displayed behind fixed sections
  - Touch scrolling not working/jumping under mobile device emulation in Chrome (https://github.com/maxim-saplin/data_table_2/issues/100)
+ - Cell and row tap events block `DataRow.onSelectChanged` event handler
+ - In order to get checkbox column visible it is necessary to have `DataTable2.showCheckboxColumn` set to true AND there must be some rows with `onSelectChanged` event handler being not null

--- a/example/lib/data_sources.dart
+++ b/example/lib/data_sources.dart
@@ -152,16 +152,14 @@ class DessertDataSource extends DataTableSource {
           : (hasZebraStripes && index.isEven
               ? MaterialStateProperty.all(Theme.of(context).highlightColor)
               : null),
-      onSelectChanged: hasRowTaps
-          ? null
-          : (value) {
-              if (dessert.selected != value) {
-                _selectedCount += value! ? 1 : -1;
-                assert(_selectedCount >= 0);
-                dessert.selected = value;
-                notifyListeners();
-              }
-            },
+      onSelectChanged: (value) {
+        if (dessert.selected != value) {
+          _selectedCount += value! ? 1 : -1;
+          assert(_selectedCount >= 0);
+          dessert.selected = value;
+          notifyListeners();
+        }
+      },
       onTap: hasRowTaps
           ? () => _showSnackbar(context, 'Tapped on row ${dessert.name}')
           : null,

--- a/lib/src/data_table_2.dart
+++ b/lib/src/data_table_2.dart
@@ -125,7 +125,6 @@ class DataTable2 extends DataTable {
     this.bottomMargin,
     super.columnSpacing,
     super.showCheckboxColumn = true,
-    this.changeSelectedOnRowTap = true,
     super.showBottomBorder = false,
     super.dividerThickness,
     this.minWidth,
@@ -250,10 +249,6 @@ class DataTable2 extends DataTable {
   /// Note: to change background color of fixed data rows use [DataTable2.headingRowColor] and
   /// individual row colors of data rows provided via [rows]
   final Color? fixedCornerColor;
-
-  /// Determines if [DataRow2.onSelectChanged] is invoked when the row is tapped
-  /// If true, [DataRow2.onSelectChanged] will be invoked when the row is tapped
-  final bool changeSelectedOnRowTap;
 
   Widget _buildCheckbox(
       {required BuildContext context,
@@ -448,12 +443,7 @@ class DataTable2 extends DataTable {
         onRowSecondaryTap != null ||
         onRowSecondaryTapDown != null) {
       label = TableRowInkWell(
-        onTap: onRowTap == null && onSelectChanged == null
-            ? null
-            : () {
-                onRowTap?.call();
-                if (changeSelectedOnRowTap) onSelectChanged?.call();
-              },
+        onTap: onRowTap ?? onSelectChanged,
         onDoubleTap: onRowDoubleTap,
         onLongPress: onRowLongPress,
         overlayColor: overlayColor,
@@ -1059,9 +1049,10 @@ class DataTable2 extends DataTable {
             context: context,
             checked: row.selected,
             onRowTap: () {
-              row.onSelectChanged?.call(!row.selected);
-              if (row is DataRow2) {
+              if (row is DataRow2 && row.onTap != null) {
                 row.onTap?.call();
+              } else {
+                row.onSelectChanged?.call(!row.selected);
               }
             },
             onCheckboxChanged: row.onSelectChanged,

--- a/lib/src/data_table_2.dart
+++ b/lib/src/data_table_2.dart
@@ -800,7 +800,7 @@ class DataTable2 extends DataTable {
                 ? tableColumnWidths.skip(actualFixedColumns).toList().asMap()
                 : null;
 
-            bool _isRowsEmpty(List<TableRow>? rows) {
+            bool isRowsEmpty(List<TableRow>? rows) {
               return rows == null || rows.isEmpty || rows[0].children!.isEmpty;
             }
 
@@ -810,10 +810,10 @@ class DataTable2 extends DataTable {
                 children: coreRows ?? [],
                 border: border == null
                     ? null
-                    : _isRowsEmpty(fixedRows) && _isRowsEmpty(fixedColumnsRows)
+                    : isRowsEmpty(fixedRows) && isRowsEmpty(fixedColumnsRows)
                         ? border
-                        : !_isRowsEmpty(fixedRows) &&
-                                !_isRowsEmpty(fixedColumnsRows)
+                        : !isRowsEmpty(fixedRows) &&
+                                !isRowsEmpty(fixedColumnsRows)
                             ? TableBorder(
                                 //top: border!.top,
                                 //left: border!.left,
@@ -822,7 +822,7 @@ class DataTable2 extends DataTable {
                                 verticalInside: border!.verticalInside,
                                 horizontalInside: border!.horizontalInside,
                                 borderRadius: border!.borderRadius)
-                            : _isRowsEmpty(fixedRows)
+                            : isRowsEmpty(fixedRows)
                                 ? TableBorder(
                                     top: border!.top,
                                     //left: border!.left,
@@ -848,7 +848,7 @@ class DataTable2 extends DataTable {
 
             if (rows.isNotEmpty) {
               if (fixedRows != null &&
-                  !_isRowsEmpty(fixedRows) &&
+                  !isRowsEmpty(fixedRows) &&
                   actualFixedColumns <
                       columns.length + (showCheckboxColumn ? 1 : 0)) {
                 fixedRowsTabel = Table(
@@ -857,7 +857,7 @@ class DataTable2 extends DataTable {
                     children: fixedRows,
                     border: border == null
                         ? null
-                        : _isRowsEmpty(fixedCornerRows)
+                        : isRowsEmpty(fixedCornerRows)
                             ? border
                             : TableBorder(
                                 top: border!.top,
@@ -869,13 +869,13 @@ class DataTable2 extends DataTable {
                                 borderRadius: border!.borderRadius));
               }
 
-              if (fixedColumnsRows != null && !_isRowsEmpty(fixedColumnsRows)) {
+              if (fixedColumnsRows != null && !isRowsEmpty(fixedColumnsRows)) {
                 fixedColumnsTable = Table(
                     columnWidths: leftWidthsAsMap,
                     children: fixedColumnsRows,
                     border: border == null
                         ? null
-                        : _isRowsEmpty(fixedCornerRows)
+                        : isRowsEmpty(fixedCornerRows)
                             ? border
                             : TableBorder(
                                 //top: border!.top,
@@ -887,14 +887,14 @@ class DataTable2 extends DataTable {
                                 borderRadius: border!.borderRadius));
               }
 
-              if (fixedCornerRows != null && !_isRowsEmpty(fixedCornerRows)) {
+              if (fixedCornerRows != null && !isRowsEmpty(fixedCornerRows)) {
                 fixedTopLeftCornerTable = Table(
                     columnWidths: leftWidthsAsMap,
                     children: fixedCornerRows,
                     border: border);
               }
 
-              Widget _addBottomMargin(Table t) =>
+              Widget addBottomMargin(Table t) =>
                   bottomMargin != null && bottomMargin! > 0
                       ? Column(
                           mainAxisSize: MainAxisSize.min,
@@ -928,7 +928,7 @@ class DataTable2 extends DataTable {
                             child: SingleChildScrollView(
                                 controller: coreHorizontalController,
                                 scrollDirection: Axis.horizontal,
-                                child: _addBottomMargin(coreTable))))
+                                child: addBottomMargin(coreTable))))
                   ]));
 
               fixedColumnAndCornerCol = fixedTopLeftCornerTable == null &&
@@ -946,8 +946,7 @@ class DataTable2 extends DataTable {
                                 child: SingleChildScrollView(
                                     controller: leftColumnVerticalContoller,
                                     scrollDirection: Axis.vertical,
-                                    child:
-                                        _addBottomMargin(fixedColumnsTable))))
+                                    child: addBottomMargin(fixedColumnsTable))))
                     ]);
             }
 

--- a/lib/src/data_table_2.dart
+++ b/lib/src/data_table_2.dart
@@ -125,6 +125,7 @@ class DataTable2 extends DataTable {
     this.bottomMargin,
     super.columnSpacing,
     super.showCheckboxColumn = true,
+    this.changeSelectedOnRowTap = true,
     super.showBottomBorder = false,
     super.dividerThickness,
     this.minWidth,
@@ -249,6 +250,10 @@ class DataTable2 extends DataTable {
   /// Note: to change background color of fixed data rows use [DataTable2.headingRowColor] and
   /// individual row colors of data rows provided via [rows]
   final Color? fixedCornerColor;
+
+  /// Determines if [DataRow2.onSelectChanged] is invoked when the row is tapped
+  /// If true, [DataRow2.onSelectChanged] will be invoked when the row is tapped
+  final bool changeSelectedOnRowTap;
 
   Widget _buildCheckbox(
       {required BuildContext context,
@@ -447,7 +452,7 @@ class DataTable2 extends DataTable {
             ? null
             : () {
                 onRowTap?.call();
-                onSelectChanged?.call();
+                if (changeSelectedOnRowTap) onSelectChanged?.call();
               },
         onDoubleTap: onRowDoubleTap,
         onLongPress: onRowLongPress,

--- a/test/chasing_coverage_test.dart
+++ b/test/chasing_coverage_test.dart
@@ -152,7 +152,7 @@ void main() {
     var asc = false;
     var trigger = StreamController();
 
-    Widget _sortedColTable(int col, bool direction) => buildTable(
+    Widget sortedColTable(int col, bool direction) => buildTable(
           sortColumnIndex: col,
           sortAscending: direction,
           dividerThickness: 0.0,
@@ -192,7 +192,7 @@ void main() {
     var widget = StreamBuilder(
         stream: trigger.stream,
         builder: (c, s) {
-          return _sortedColTable(sortCol, asc);
+          return sortedColTable(sortCol, asc);
         });
 
     await tester.pumpWidget(MaterialApp(home: Material(child: widget)));

--- a/test/custom_features_test.dart
+++ b/test/custom_features_test.dart
@@ -1426,28 +1426,28 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      int _numebrOfCheckboxes(bool cheked) => find
+      int numebrOfCheckboxes(bool cheked) => find
           .byType(Checkbox)
           .evaluate()
           .where((e) => (e.widget as Checkbox).value == cheked)
           .length;
 
-      expect(_numebrOfCheckboxes(false), 11);
+      expect(numebrOfCheckboxes(false), 11);
 
       await tester.tap(find.byType(Checkbox).first);
       await tester.pumpAndSettle();
-      expect(_numebrOfCheckboxes(true), 11);
+      expect(numebrOfCheckboxes(true), 11);
 
       await tester.tap(find.byIcon(Icons.chevron_right)); // page 2
       await tester.pumpAndSettle();
-      expect(_numebrOfCheckboxes(true), 11);
+      expect(numebrOfCheckboxes(true), 11);
       await tester.tap(find.byIcon(Icons.chevron_right)); // page 3
       await tester.pumpAndSettle();
-      expect(_numebrOfCheckboxes(true), 11);
+      expect(numebrOfCheckboxes(true), 11);
 
       await tester.tap(find.byType(Checkbox).first);
       await tester.pumpAndSettle();
-      expect(_numebrOfCheckboxes(false), 11);
+      expect(numebrOfCheckboxes(false), 11);
     });
 
     testWidgets('Select/deselect all on page', (WidgetTester tester) async {
@@ -1470,31 +1470,31 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      int _numebrOfCheckboxes(bool cheked) => find
+      int numebrOfCheckboxes(bool cheked) => find
           .byType(Checkbox)
           .evaluate()
           .where((e) => (e.widget as Checkbox).value == cheked)
           .length;
 
-      expect(_numebrOfCheckboxes(false), 11);
+      expect(numebrOfCheckboxes(false), 11);
 
       await tester.tap(find.byType(Checkbox).first);
       await tester.pumpAndSettle();
-      expect(_numebrOfCheckboxes(true), 11);
+      expect(numebrOfCheckboxes(true), 11);
 
       await tester.tap(find.byIcon(Icons.chevron_right)); // page 2
       await tester.pumpAndSettle();
-      expect(_numebrOfCheckboxes(false), 11);
+      expect(numebrOfCheckboxes(false), 11);
       await tester.tap(find.byIcon(Icons.chevron_right)); // page 3
       await tester.pumpAndSettle();
-      expect(_numebrOfCheckboxes(false), 11);
+      expect(numebrOfCheckboxes(false), 11);
 
       await tester.tap(find.byType(Checkbox).first);
       await tester.pumpAndSettle();
-      expect(_numebrOfCheckboxes(true), 11);
+      expect(numebrOfCheckboxes(true), 11);
       await tester.tap(find.byType(Checkbox).first);
       await tester.pumpAndSettle();
-      expect(_numebrOfCheckboxes(false), 11);
+      expect(numebrOfCheckboxes(false), 11);
     });
   });
 

--- a/test/data_table_2_data_column_2_test.dart
+++ b/test/data_table_2_data_column_2_test.dart
@@ -377,7 +377,7 @@ void main() {
     // Wait 500ms to get tap registered instead of double tap
     await tester.pump(const Duration(milliseconds: 500));
 
-    expect(log, <String>['row-tap: Cupcake', 'row-selected: Cupcake']);
+    expect(log, <String>['row-tap: Cupcake']);
     log.clear();
 
     // Since cell has tap events row won't be se;lected
@@ -392,7 +392,7 @@ void main() {
     // Wait 500ms to get tap registered instead of double tap
     await tester.pump(const Duration(milliseconds: 500));
 
-    expect(log, <String>['row-tap: Cupcake', 'row-selected: Cupcake']);
+    expect(log, <String>['row-tap: Cupcake']);
     log.clear();
 
     await tester.tap(find.text('Cupcake'), buttons: kSecondaryMouseButton);

--- a/test/data_table_2_test.dart
+++ b/test/data_table_2_test.dart
@@ -255,8 +255,7 @@ void main() {
     await tester.tapAt(Offset(xy.dx - 10, xy.dy - 20));
     await tester.pump(const Duration(milliseconds: 300));
 
-    expect(
-        log, <String>['row-selected: Frozen yogurt', 'row-tap: Frozen yogurt']);
+    expect(log, <String>['row-tap: Frozen yogurt']);
     log.clear();
 
     await tester.tap(find.text('Cupcake'));
@@ -264,7 +263,7 @@ void main() {
         milliseconds:
             300)); // if there's a double tap event you need to give some time to let input system decide there's no second tap following and onTap event is good to be fired
 
-    expect(log, <String>['row-tap: Cupcake', 'row-selected: Cupcake']);
+    expect(log, <String>['row-tap: Cupcake']);
     log.clear();
 
     await tester.longPress(find.text('Cupcake'));
@@ -496,11 +495,10 @@ void main() {
     Widget buildTable({
       int? sortColumnIndex,
       bool sortAscending = true,
-      changeSelectedOnRowTap = true,
+      bool setOnTap = true,
     }) {
       return DataTable2(
         sortColumnIndex: sortColumnIndex,
-        changeSelectedOnRowTap: changeSelectedOnRowTap,
         sortAscending: sortAscending,
         onSelectAll: (bool? value) {
           log.add('select-all: $value');
@@ -525,9 +523,11 @@ void main() {
             onSelectChanged: (bool? selected) {
               log.add('row-selected: ${dessert.name}');
             },
-            onTap: () {
-              log.add('row-tap: ${dessert.name}');
-            },
+            onTap: setOnTap
+                ? () {
+                    log.add('row-tap: ${dessert.name}');
+                  }
+                : null,
             onSecondaryTap: () {
               log.add('row-secondaryTap: ${dessert.name}');
             },
@@ -561,14 +561,14 @@ void main() {
     // Wait 500ms to get tap registered instead of double tap
     await tester.pump(const Duration(milliseconds: 500));
 
-    expect(log, <String>['row-tap: Cupcake', 'row-selected: Cupcake']);
+    expect(log, <String>['row-tap: Cupcake']);
     log.clear();
 
     await tester.tap(find.text('305'));
     // Wait 500ms to get tap registered instead of double tap
     await tester.pump(const Duration(milliseconds: 500));
 
-    expect(log, <String>['row-tap: Cupcake', 'row-selected: Cupcake']);
+    expect(log, <String>['row-tap: Cupcake']);
     log.clear();
 
     await tester.tap(find.text('Cupcake'), buttons: kSecondaryMouseButton);
@@ -597,7 +597,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: Material(
         child: buildTable(
-          changeSelectedOnRowTap: false,
+          setOnTap: false,
         ),
       ),
     ));
@@ -606,7 +606,7 @@ void main() {
     // Wait 500ms to get tap registered instead of double tap
     await tester.pump(const Duration(milliseconds: 500));
 
-    expect(log, <String>['row-tap: Cupcake']);
+    expect(log, <String>['row-selected: Cupcake']);
     log.clear();
   });
 

--- a/test/data_table_2_test.dart
+++ b/test/data_table_2_test.dart
@@ -493,9 +493,14 @@ void main() {
       (WidgetTester tester) async {
     final List<String> log = <String>[];
 
-    Widget buildTable({int? sortColumnIndex, bool sortAscending = true}) {
+    Widget buildTable({
+      int? sortColumnIndex,
+      bool sortAscending = true,
+      changeSelectedOnRowTap = true,
+    }) {
       return DataTable2(
         sortColumnIndex: sortColumnIndex,
+        changeSelectedOnRowTap: changeSelectedOnRowTap,
         sortAscending: sortAscending,
         onSelectAll: (bool? value) {
           log.add('select-all: $value');
@@ -587,6 +592,21 @@ void main() {
 
     await tester.longPress(find.text('305'));
     expect(log, <String>['row-longPress: Cupcake']);
+    log.clear();
+
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: buildTable(
+          changeSelectedOnRowTap: false,
+        ),
+      ),
+    ));
+
+    await tester.tap(find.text('Cupcake'));
+    // Wait 500ms to get tap registered instead of double tap
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(log, <String>['row-tap: Cupcake']);
     log.clear();
   });
 

--- a/test/data_table_2_test.dart
+++ b/test/data_table_2_test.dart
@@ -88,6 +88,12 @@ void main() {
     expect(log, <String>['select-all: true']);
     log.clear();
 
+    // clicking on a cell empty space outside chekbox should still select the row
+    var c = tester.getCenter(find.byType(Checkbox).at(1));
+    await tester.tapAt(Offset(c.dx - 16, c.dy - 16));
+    expect(log, <String>['row-selected: Frozen yogurt']);
+    log.clear();
+
     await tester.tap(find.text('Cupcake'));
 
     expect(log, <String>['row-selected: Cupcake']);

--- a/test/fixed_rows_cols_test.dart
+++ b/test/fixed_rows_cols_test.dart
@@ -65,7 +65,7 @@ void main() {
           Colors.red);
     });
 
-    Color? _colorFromTextInContainer(String text) {
+    Color? colorFromTextInContainer(String text) {
       return (find
               .ancestor(of: find.text(text), matching: find.byType(Container))
               .evaluate()
@@ -94,9 +94,9 @@ void main() {
       expect(containers.where((c) => c.color == Colors.blue).length, 0);
       expect(containers.where((c) => c.color == Colors.red).length, 22);
 
-      expect(_colorFromTextInContainer('Name'), Colors.red);
-      expect(_colorFromTextInContainer('Carbs'), null);
-      expect(_colorFromTextInContainer('KitKat'), Colors.red);
+      expect(colorFromTextInContainer('Name'), Colors.red);
+      expect(colorFromTextInContainer('Carbs'), null);
+      expect(colorFromTextInContainer('KitKat'), Colors.red);
     });
 
     testWidgets('3 cols, 0 rows', (WidgetTester tester) async {
@@ -119,11 +119,11 @@ void main() {
       expect(containers.where((c) => c.color == Colors.blue).length, 0);
       expect(containers.where((c) => c.color == Colors.red).length, 33);
 
-      expect(_colorFromTextInContainer('Name'), Colors.red);
-      expect(_colorFromTextInContainer('Calories'), Colors.red);
-      expect(_colorFromTextInContainer('Carbs'), null);
-      expect(_colorFromTextInContainer('KitKat'), Colors.red);
-      expect(_colorFromTextInContainer('518'), Colors.red);
+      expect(colorFromTextInContainer('Name'), Colors.red);
+      expect(colorFromTextInContainer('Calories'), Colors.red);
+      expect(colorFromTextInContainer('Carbs'), null);
+      expect(colorFromTextInContainer('KitKat'), Colors.red);
+      expect(colorFromTextInContainer('518'), Colors.red);
     });
 
     testWidgets('1 col, 1 row', (WidgetTester tester) async {
@@ -157,11 +157,11 @@ void main() {
               .color!,
           Colors.blue);
 
-      expect(_colorFromTextInContainer('Name'), null);
-      expect(_colorFromTextInContainer('Calories'), null);
-      expect(_colorFromTextInContainer('Carbs'), null);
-      expect(_colorFromTextInContainer('KitKat'), null);
-      expect(_colorFromTextInContainer('518'), null);
+      expect(colorFromTextInContainer('Name'), null);
+      expect(colorFromTextInContainer('Calories'), null);
+      expect(colorFromTextInContainer('Carbs'), null);
+      expect(colorFromTextInContainer('KitKat'), null);
+      expect(colorFromTextInContainer('518'), null);
     });
 
     testWidgets('3 cols, 3 rows', (WidgetTester tester) async {
@@ -195,11 +195,11 @@ void main() {
               .color!,
           Colors.blue);
 
-      expect(_colorFromTextInContainer('Name'), Colors.blue);
-      expect(_colorFromTextInContainer('Calories'), Colors.blue);
-      expect(_colorFromTextInContainer('Carbs'), null);
-      expect(_colorFromTextInContainer('KitKat'), Colors.red);
-      expect(_colorFromTextInContainer('518'), Colors.red);
+      expect(colorFromTextInContainer('Name'), Colors.blue);
+      expect(colorFromTextInContainer('Calories'), Colors.blue);
+      expect(colorFromTextInContainer('Carbs'), null);
+      expect(colorFromTextInContainer('KitKat'), Colors.red);
+      expect(colorFromTextInContainer('518'), Colors.red);
     });
   });
 


### PR DESCRIPTION
I have `showCheckboxes` set to `true`. I have also set both `DataRow2.onTap` (navigates to a new page) and `DataRow2.onSelectChanged` (enables the checkbox and checkbox action as the checkboxes [should not display without it](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/data_table.dart#L595)).

The users of this package have no way of overriding the `onTap` function without the incurring an unexpected side-effect. Per the [original implementation](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/data_table.dart#L269), `onSelectChanged` should not be invoked if any of the following are set:
- `DataCell.onTap`
- `DataCell.onDoubleTap`
- `DataCell.onLongPress`
- `DataCell.onTapDown`
- `DataCell.onTapCancel`

If we apply the transitive property, we can safely surmise that `DataRow2.onSelectChanged` should not be invoked if `DataRow2.onTap` is set.