### PR TITLE
Implementation for Hide Columns Header

### DIFF
--- a/example/lib/nav_helper.dart
+++ b/example/lib/nav_helper.dart
@@ -45,7 +45,14 @@ const Map<String, List<String>> routeOptions = {
     rowHeightOverrides,
     hideColumnHeaders,
   ],
-  '/paginated2': [dflt, noData, autoRows, custPager, defaultSorting],
+  '/paginated2': [
+    dflt,
+    noData,
+    autoRows,
+    custPager,
+    defaultSorting,
+    hideColumnHeaders
+  ],
   '/datatable2fixedmn': [
     dataTable2,
     paginatedFixedRowsCols,

--- a/example/lib/nav_helper.dart
+++ b/example/lib/nav_helper.dart
@@ -26,6 +26,7 @@ const fixedColumnWidth = 'Fixed column width';
 const dataTable2 = 'DataTable2';
 const paginatedFixedRowsCols = 'PaginatedDataTable2';
 const asyncPaginatedFixedRowsCols = 'AsyncPaginatedDataTable2';
+const hideColumnHeaders = 'Hide column headers';
 
 /// Async sample that emulates network error and allow retrying load operation
 const asyncErrors = "Errors/Retries";
@@ -41,7 +42,8 @@ const Map<String, List<String>> routeOptions = {
     showBordersWithZebraStripes,
     fixedColumnWidth,
     rowTaps,
-    rowHeightOverrides
+    rowHeightOverrides,
+    hideColumnHeaders,
   ],
   '/paginated2': [dflt, noData, autoRows, custPager, defaultSorting],
   '/datatable2fixedmn': [

--- a/example/lib/screens/data_table2.dart
+++ b/example/lib/screens/data_table2.dart
@@ -71,6 +71,7 @@ class DataTable2DemoState extends State<DataTable2Demo> {
       child: DataTable2(
         columnSpacing: 12,
         horizontalMargin: 12,
+        hideColumnsHeader: getCurrentRouteOption(context) == hideColumnHeaders,
         border: getCurrentRouteOption(context) == fixedColumnWidth
             ? TableBorder(
                 top: const BorderSide(color: Colors.black),

--- a/example/lib/screens/paginated_data_table2.dart
+++ b/example/lib/screens/paginated_data_table2.dart
@@ -126,6 +126,7 @@ class PaginatedDataTable2DemoState extends State<PaginatedDataTable2Demo> {
         wrapInCard: false,
         headingRowColor:
             MaterialStateColor.resolveWith((states) => Colors.grey[200]!),
+        hideColumnsHeader: getCurrentRouteOption(context) == hideColumnHeaders,
         header:
             Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
           const Text('PaginatedDataTable2'),

--- a/lib/src/data_table_2.dart
+++ b/lib/src/data_table_2.dart
@@ -139,6 +139,7 @@ class DataTable2 extends DataTable {
     this.lmRatio = 1.2,
     this.sortArrowAnimationDuration = const Duration(milliseconds: 150),
     this.sortArrowIcon = Icons.arrow_upward,
+    this.hideColumnsHeader = false,
     required super.rows,
   })  : assert(fixedLeftColumns >= 0),
         assert(fixedTopRows >= 0) {
@@ -247,6 +248,10 @@ class DataTable2 extends DataTable {
   /// this color is static and doesn't repond to state change
   /// Note: to change background color of fixed data rows use [DataTable2.headingRowColor]
   final Color? fixedCornerColor;
+
+  /// By default the table shows the columns header row.
+  /// Set to true in order to hide the columns header row.
+  final bool hideColumnsHeader;
 
   Widget _buildCheckbox(
       {required BuildContext context,
@@ -918,22 +923,23 @@ class DataTable2 extends DataTable {
               fixedRowsAndCoreCol = Scrollbar(
                   controller: coreHorizontalController,
                   child: Column(mainAxisSize: MainAxisSize.min, children: [
-                    ScrollConfiguration(
-                        behavior: ScrollConfiguration.of(context)
-                            .copyWith(scrollbars: false),
-                        child: SingleChildScrollView(
-                            controller: fixedRowsHorizontalController,
-                            scrollDirection: Axis.horizontal,
-                            child: (fixedRowsTabel != null)
-                                ? fixedRowsTabel
-                                // WOrkaround for a bug when there's no horizontal scrollbar should there be no this SingleChildScrollView. I.e. originally this part was ommited and not scrollable was added to the column if not fixed top row was visible
-                                : SizedBox(
-                                    height: 0,
-                                    width: widths.fold<double>(
-                                        0,
-                                        (previousValue, value) =>
-                                            previousValue + value),
-                                  ))),
+                    if (!hideColumnsHeader)
+                      ScrollConfiguration(
+                          behavior: ScrollConfiguration.of(context)
+                              .copyWith(scrollbars: false),
+                          child: SingleChildScrollView(
+                              controller: fixedRowsHorizontalController,
+                              scrollDirection: Axis.horizontal,
+                              child: (fixedRowsTabel != null)
+                                  ? fixedRowsTabel
+                                  // WOrkaround for a bug when there's no horizontal scrollbar should there be no this SingleChildScrollView. I.e. originally this part was ommited and not scrollable was added to the column if not fixed top row was visible
+                                  : SizedBox(
+                                      height: 0,
+                                      width: widths.fold<double>(
+                                          0,
+                                          (previousValue, value) =>
+                                              previousValue + value),
+                                    ))),
                     Flexible(
                         fit: FlexFit.tight,
                         child: SingleChildScrollView(

--- a/lib/src/data_table_2.dart
+++ b/lib/src/data_table_2.dart
@@ -1226,7 +1226,10 @@ class DataTable2 extends DataTable {
           );
           final Border border = showBottomBorder
               ? Border(bottom: borderSide)
-              : Border(top: borderSide);
+              : Border(
+                  top: hideColumnsHeader && index == 0
+                      ? BorderSide.none
+                      : borderSide);
           return TableRow(
             key: rows[rowStartIndex + actualIndex].key,
             decoration: BoxDecoration(

--- a/lib/src/paginated_data_table_2.dart
+++ b/lib/src/paginated_data_table_2.dart
@@ -202,6 +202,7 @@ class PaginatedDataTable2 extends StatefulWidget {
     this.autoRowsToHeight = false,
     this.smRatio = 0.67,
     this.lmRatio = 1.2,
+    this.hideColumnsHeader = false,
   })  : assert(actions == null || (header != null)),
         assert(columns.isNotEmpty),
         assert(sortColumnIndex == null ||
@@ -448,6 +449,10 @@ class PaginatedDataTable2 extends StatefulWidget {
 
   /// Exposes scroll controller of the SingleChildScrollView that makes data rows vertically scrollable
   final ScrollController? scrollController;
+
+  /// By default the table shows the columns header row.
+  /// Set to true in order to hide the columns header row.
+  final bool hideColumnsHeader;
 
   @override
   PaginatedDataTable2State createState() => PaginatedDataTable2State();
@@ -721,6 +726,7 @@ class PaginatedDataTable2State extends State<PaginatedDataTable2> {
           border: widget.border,
           smRatio: widget.smRatio,
           lmRatio: widget.lmRatio,
+          hideColumnsHeader: widget.hideColumnsHeader,
         ),
       ),
     );

--- a/test/data_table_2_test.dart
+++ b/test/data_table_2_test.dart
@@ -2302,4 +2302,32 @@ void main() {
     expect(tableBorder?.bottom.width, null);
     expect(tableBorder?.top.color, null);
   });
+
+  testWidgets('DataTable2 set hide columns header',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: DataTable2(
+            hideColumnsHeader: true,
+            columns: const <DataColumn>[
+              DataColumn(
+                label: Text('Dessert'),
+              ),
+            ],
+            rows: const <DataRow2>[
+              DataRow2(
+                cells: <DataCell>[
+                  DataCell(
+                    Text('Lollipop'), // wraps
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    expect(find.text('Dessert'), findsNothing);
+  });
 }

--- a/test/paginated_data_table2_test.dart
+++ b/test/paginated_data_table2_test.dart
@@ -1013,4 +1013,29 @@ void main() {
 
     await binding.setSurfaceSize(null);
   });
+
+  testWidgets('PaginatedDataTable2 set hide columns header',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: PaginatedDataTable2(
+        header: const Text('HEADER'),
+        source: TestDataSource(),
+        rowsPerPage: 8,
+        hideColumnsHeader: true,
+        availableRowsPerPage: const <int>[
+          8,
+          9,
+        ],
+        onRowsPerPageChanged: (int? rowsPerPage) {},
+        columns: const <DataColumn>[
+          DataColumn(label: Text('COL1')),
+          DataColumn(label: Text('COL2')),
+          DataColumn(label: Text('COL3')),
+        ],
+      ),
+    ));
+    expect(find.text('COL1'), findsNothing);
+    expect(find.text('COL2'), findsNothing);
+    expect(find.text('COL3'), findsNothing);
+  });
 }


### PR DESCRIPTION
- added a flag `hideColumnsHeader` to data_table_2 to optionally hide the columns header
- added example and test

Sometimes we would like to show a table with self explained columns that don't need to show (each row is a single element). A workaround is to give each column label an empty string, but it leaves the top part of the table as an empty white space.

With this flag the user can optionally render the columns header regardless of the values and not have a big empty space at the top of the table.