### PR TITLE
Feature/checkbox alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.5.6
+- Added `checkboxAlignment` to widgets
+
 ## 2.5.5
 - Customizing checkboxes in DataTable2 via `headingCheckboxTheme` and `datarowCheckboxTheme`
 

--- a/example/lib/screens/data_table2.dart
+++ b/example/lib/screens/data_table2.dart
@@ -83,6 +83,7 @@ class DataTable2DemoState extends State<DataTable2Demo> {
             headingTextStyle: const TextStyle(color: Colors.white),
             headingCheckboxTheme: const CheckboxThemeData(
                 side: BorderSide(color: Colors.white, width: 2.0)),
+            //checkboxAlignment: Alignment.topLeft,
             isHorizontalScrollBarVisible: true,
             isVerticalScrollBarVisible: true,
             columnSpacing: 12,

--- a/lib/src/async_paginated_data_table_2.dart
+++ b/lib/src/async_paginated_data_table_2.dart
@@ -13,6 +13,7 @@ enum SelectionState { none, include, exclude }
 
 class AsyncRowsResponse {
   AsyncRowsResponse(this.totalRows, this.rows);
+
   final int totalRows;
   final List<DataRow> rows;
 }
@@ -48,6 +49,7 @@ abstract class AsyncDataTableSource extends DataTableSource {
   Set<LocalKey> get selectionRowKeys => _selectionRowKeys;
 
   Object? _error;
+
   Object? get error => _error;
 
   List<DataRow> _rows = [];
@@ -349,6 +351,7 @@ class AsyncPaginatedDataTable2 extends PaginatedDataTable2 {
       super.dragStartBehavior = DragStartBehavior.start,
       required super.source,
       super.checkboxHorizontalMargin,
+      super.checkboxAlignment,
       super.wrapInCard = true,
       super.minWidth,
       super.fit = FlexFit.tight,

--- a/lib/src/data_table_2.dart
+++ b/lib/src/data_table_2.dart
@@ -126,7 +126,7 @@ class DataTable2 extends DataTable {
     this.datarowCheckboxTheme,
     super.horizontalMargin,
     super.checkboxHorizontalMargin,
-    this.checkboxAlignment,
+    this.checkboxAlignment = Alignment.center,
     this.bottomMargin,
     super.columnSpacing,
     super.showCheckboxColumn = true,
@@ -209,7 +209,7 @@ class DataTable2 extends DataTable {
 
   /// Alignment of the checkbox if it is displayed
   /// Defaults to the [Alignment.center]
-  final Alignment? checkboxAlignment;
+  final Alignment checkboxAlignment;
 
   /// Overrides theme of the checkbox that is displayed in the checkbox column
   /// in each data row (should checkboxes be enabled)
@@ -333,7 +333,7 @@ class DataTable2 extends DataTable {
     Widget contents = Semantics(
       container: true,
       child: wrapInContainer(Align(
-        alignment: checkboxAlignment ?? Alignment.center,
+        alignment: checkboxAlignment,
         child: Theme(
             data: ThemeData(checkboxTheme: checkboxTheme),
             child: Checkbox(

--- a/lib/src/data_table_2.dart
+++ b/lib/src/data_table_2.dart
@@ -96,8 +96,8 @@ class DataRow2 extends DataRow {
   /// Row double tap handler, won't be called if tapped cell has any tap event handlers
   final GestureTapCallback? onDoubleTap;
 
-  // /// Row long press handler, won't be called if tapped cell has any tap event handlers
-  // final GestureLongPressCallback? onLongPress;
+// /// Row long press handler, won't be called if tapped cell has any tap event handlers
+// final GestureLongPressCallback? onLongPress;
 }
 
 /// In-place replacement of standard [DataTable] widget, mimics it API.
@@ -126,6 +126,7 @@ class DataTable2 extends DataTable {
     this.datarowCheckboxTheme,
     super.horizontalMargin,
     super.checkboxHorizontalMargin,
+    this.checkboxAlignment,
     this.bottomMargin,
     super.columnSpacing,
     super.showCheckboxColumn = true,
@@ -205,6 +206,10 @@ class DataTable2 extends DataTable {
   /// Overrides theme of the checkbox that is displayed in the leftmost corner
   /// of the heading (should checkboxes be enabled)
   final CheckboxThemeData? headingCheckboxTheme;
+
+  /// Alignment of the checkbox if it is displayed
+  /// Defaults to the [Alignment.center]
+  final Alignment? checkboxAlignment;
 
   /// Overrides theme of the checkbox that is displayed in the checkbox column
   /// in each data row (should checkboxes be enabled)
@@ -327,7 +332,8 @@ class DataTable2 extends DataTable {
 
     Widget contents = Semantics(
       container: true,
-      child: wrapInContainer(Center(
+      child: wrapInContainer(Align(
+        alignment: checkboxAlignment ?? Alignment.center,
         child: Theme(
             data: ThemeData(checkboxTheme: checkboxTheme),
             child: Checkbox(

--- a/lib/src/data_table_2.dart
+++ b/lib/src/data_table_2.dart
@@ -321,6 +321,7 @@ class DataTable2 extends DataTable {
         getMinMaxRowHeight(dataTableTheme);
 
     Widget wrapInContainer(Widget child) => Container(
+        alignment: checkboxAlignment,
         constraints: BoxConstraints(
             minHeight: rowHeight ?? effectiveDataRowMinHeight,
             maxHeight: rowHeight ?? effectiveDataRowMaxHeight),
@@ -332,16 +333,15 @@ class DataTable2 extends DataTable {
 
     Widget contents = Semantics(
       container: true,
-      child: wrapInContainer(Align(
-        alignment: checkboxAlignment,
-        child: Theme(
+      child: wrapInContainer(
+        Theme(
             data: ThemeData(checkboxTheme: checkboxTheme),
             child: Checkbox(
               value: checked,
               onChanged: onCheckboxChanged,
               tristate: tristate,
             )),
-      )),
+      ),
     );
     if (onRowTap != null) {
       contents = TableRowInkWell(

--- a/lib/src/paginated_data_table_2.dart
+++ b/lib/src/paginated_data_table_2.dart
@@ -401,7 +401,7 @@ class PaginatedDataTable2 extends StatefulWidget {
 
   /// Alignment of the checkbox if it is displayed
   /// Defaults to the [Alignment.center]
-  final Alignment? checkboxAlignment;
+  final Alignment checkboxAlignment;
 
   /// If set, the table will stop shrinking below the threshold and provide
   /// horizontal scrolling. Useful for the cases with narrow screens (e.g. portrait phone orientation)

--- a/lib/src/paginated_data_table_2.dart
+++ b/lib/src/paginated_data_table_2.dart
@@ -195,6 +195,7 @@ class PaginatedDataTable2 extends StatefulWidget {
     this.dragStartBehavior = DragStartBehavior.start,
     required this.source,
     this.checkboxHorizontalMargin,
+    this.checkboxAlignment = Alignment.center,
     this.wrapInCard = true,
     this.minWidth,
     this.fit = FlexFit.tight,
@@ -397,6 +398,10 @@ class PaginatedDataTable2 extends StatefulWidget {
   /// of the table and the checkbox, as well as the margin between the checkbox
   /// and the content in the first data column. This value defaults to 24.0.
   final double? checkboxHorizontalMargin;
+
+  /// Alignment of the checkbox if it is displayed
+  /// Defaults to the [Alignment.center]
+  final Alignment? checkboxAlignment;
 
   /// If set, the table will stop shrinking below the threshold and provide
   /// horizontal scrolling. Useful for the cases with narrow screens (e.g. portrait phone orientation)
@@ -744,6 +749,7 @@ class PaginatedDataTable2State extends State<PaginatedDataTable2> {
           headingRowHeight: widget.headingRowHeight,
           horizontalMargin: widget.horizontalMargin,
           checkboxHorizontalMargin: widget.checkboxHorizontalMargin,
+          checkboxAlignment: widget.checkboxAlignment,
           columnSpacing: widget.columnSpacing,
           showCheckboxColumn: widget.showCheckboxColumn,
           showBottomBorder: true,
@@ -779,9 +785,8 @@ class PaginatedDataTable2State extends State<PaginatedDataTable2> {
       }).toList();
       if (!widget.autoRowsToHeight) {
         footerWidgets.addAll(<Widget>[
-          Container(
-              width:
-                  14.0), // to match trailing padding in case we overflow and end up scrolling
+          Container(width: 14.0),
+          // to match trailing padding in case we overflow and end up scrolling
           Text(localizations.rowsPerPageTitle),
           ConstrainedBox(
             constraints: const BoxConstraints(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: data_table_2
 description: In-place substitute for Flutter's DataTable and PaginatedDataTable with fixed/sticky headers and few extra features
-version: 2.5.4
+version: 2.5.6
 homepage: https://github.com/maxim-saplin/data_table_2
 repository: https://github.com/maxim-saplin/data_table_2
 

--- a/test/data_table_2_test.dart
+++ b/test/data_table_2_test.dart
@@ -413,7 +413,7 @@ void main() {
 
     // Tap on an empty space near checkbox
     var xy = tester.getCenter(find.ancestor(
-        of: find.byType(Checkbox).at(1), matching: find.byType(Center)));
+        of: find.byType(Checkbox).at(1), matching: find.byType(Align)));
 
     await tester.tapAt(Offset(xy.dx - 10, xy.dy - 20));
     await tester.pump(const Duration(milliseconds: 300));


### PR DESCRIPTION
Currently the checkbox on the starting side of table always aligns to the centre.
In our requirement, we needed the checkbox to be on the top left corner. But there is no way to do so without maintaining our own repo of this repo. We are extensively using this package and it's working wonders for us. We thought someone else might also need to align the checkbox and thought of raising a PR.
We have tested the code and it's working fine. 
We also needed to make a change in the test case where we are exepecting a `Center` widget as parent of Checkbox, because it's going to be `Align` now. 
Passing the `alignment` on the Container inside `wrapInContainer` method would not work because the `Center` is always there, so we are required to replace the `Center` with `Align` to have an ability to align the checkbox. We thought `Align` would be the best option to replace `Center` with, because `Center` extends `Align`