### PR TITLE
Fix wrong parameter name in AsyncDataTableSource.getRow method

### DIFF
--- a/example/lib/data_sources.dart
+++ b/example/lib/data_sources.dart
@@ -257,8 +257,8 @@ class DessertDataSourceAsync extends AsyncDataTableSource {
   }
 
   @override
-  Future<AsyncRowsResponse> getRows(int start, int end) async {
-    print('getRows($start, $end)');
+  Future<AsyncRowsResponse> getRows(int startIndex, int count) async {
+    print('getRows($startIndex, $count)');
     if (_errorCounter != null) {
       _errorCounter = _errorCounter! + 1;
 
@@ -268,19 +268,18 @@ class DessertDataSourceAsync extends AsyncDataTableSource {
       }
     }
 
-    var index = start;
     final format = NumberFormat.decimalPercentPattern(
       locale: 'en',
       decimalDigits: 0,
     );
-    assert(index >= 0);
+    assert(startIndex >= 0);
 
     // List returned will be empty is there're fewer items than startingAt
     var x = _empty
         ? await Future.delayed(const Duration(milliseconds: 2000),
             () => DesertsFakeWebServiceResponse(0, []))
         : await _repo.getData(
-            start, end, _caloriesFilter, _sortColumn, _sortAscending);
+            startIndex, count, _caloriesFilter, _sortColumn, _sortAscending);
 
     var r = AsyncRowsResponse(
         x.totalRecords,

--- a/lib/src/async_paginated_data_table_2.dart
+++ b/lib/src/async_paginated_data_table_2.dart
@@ -60,12 +60,12 @@ abstract class AsyncDataTableSource extends DataTableSource {
   int _prevFetchCount = 0;
 
   /// Override this method to allow the data source asynchronously
-  /// fetch data (e.g. from a server) and convert them to [DataRow]/[DataRow2]
-  /// entities consumed by [AsyncPaginatedDataTable2] widget.
+  /// fetch [count] data beginning from [start] (e.g. from a server) and convert
+  /// them to [DataRow]/[DataRow2] entities consumed by [AsyncPaginatedDataTable2] widget.
   /// Note that besides rows this method is also supposed to return
   /// the total number of available rows (both values are packed into [AsyncRowsResponse] instance
   /// returned from this method)
-  Future<AsyncRowsResponse> getRows(int start, int end);
+  Future<AsyncRowsResponse> getRows(int startIndex, int count);
 
   DataRow _clone(DataRow row, bool? selected) {
     if (row is DataRow2) {


### PR DESCRIPTION
Second parameter was called `end` but must be `count`.