### PR TITLE
Add option to hide heading checkbox in data table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.5.12
+- Add option to hide heading checkbox in data table PR#270
+
 ## 2.5.11
 - Fixed Async example (range selector)
 - Added `isHorizontalScrollBarVisible` and `isVerticalScrollBarVisible` to `PaginatedDataTable` and `AsyncPaginatedDataTable`

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -182,7 +182,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					33CC10EC2044A3C60003C045 = {

--- a/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/lib/src/data_table_2.dart
+++ b/lib/src/data_table_2.dart
@@ -250,8 +250,9 @@ class DataTable2 extends DataTable {
   /// Defaults to the [Alignment.center]
   final Alignment checkboxAlignment;
 
-  /// Display heading checkbox
-  /// Default set to true
+  /// Whether to display heading checkbox or not if the checkbox column is present. Defaults to true.
+  /// Also check [DataTable.showCheckboxColumn] for details
+  /// on how to control the checkbox column visibility
   final bool showHeadingCheckBox;
 
   /// Overrides theme of the checkbox that is displayed in the checkbox column
@@ -1169,16 +1170,18 @@ class DataTable2 extends DataTable {
 
       // Create heading twice, in the heading row used as back-up for the case of no data and any of the xxx_rows table
 
-
-        headingRow.children[0] = showHeadingCheckBox ? _buildCheckbox(
-            context: context,
-            checked: someChecked ? null : allChecked,
-            onRowTap: null,
-            onCheckboxChanged: (bool? checked) => _handleSelectAll(checked, someChecked),
-            overlayColor: null,
-            checkboxTheme: headingCheckboxTheme,
-            tristate: true,
-            rowHeight: headingHeight) : const SizedBox();
+      headingRow.children[0] = showHeadingCheckBox
+          ? _buildCheckbox(
+              context: context,
+              checked: someChecked ? null : allChecked,
+              onRowTap: null,
+              onCheckboxChanged: (bool? checked) =>
+                  _handleSelectAll(checked, someChecked),
+              overlayColor: null,
+              checkboxTheme: headingCheckboxTheme,
+              tristate: true,
+              rowHeight: headingHeight)
+          : const SizedBox();
 
       if (fixedCornerRows != null) {
         fixedCornerRows[0].children[0] = headingRow.children[0];

--- a/lib/src/data_table_2.dart
+++ b/lib/src/data_table_2.dart
@@ -166,6 +166,7 @@ class DataTable2 extends DataTable {
     this.checkboxAlignment = Alignment.center,
     this.bottomMargin,
     super.columnSpacing,
+    this.showHeadingCheckBox = true,
     super.showCheckboxColumn = true,
     super.showBottomBorder = false,
     super.dividerThickness,
@@ -248,6 +249,10 @@ class DataTable2 extends DataTable {
   /// Alignment of the checkbox if it is displayed
   /// Defaults to the [Alignment.center]
   final Alignment checkboxAlignment;
+
+  /// Display heading checkbox
+  /// Default set to true
+  final bool showHeadingCheckBox;
 
   /// Overrides theme of the checkbox that is displayed in the checkbox column
   /// in each data row (should checkboxes be enabled)
@@ -1163,16 +1168,17 @@ class DataTable2 extends DataTable {
       tableColumns[0] = FixedColumnWidth(checkBoxWidth);
 
       // Create heading twice, in the heading row used as back-up for the case of no data and any of the xxx_rows table
-      headingRow.children[0] = _buildCheckbox(
-          context: context,
-          checked: someChecked ? null : allChecked,
-          onRowTap: null,
-          onCheckboxChanged: (bool? checked) =>
-              _handleSelectAll(checked, someChecked),
-          overlayColor: null,
-          checkboxTheme: headingCheckboxTheme,
-          tristate: true,
-          rowHeight: headingHeight);
+
+
+        headingRow.children[0] = showHeadingCheckBox ? _buildCheckbox(
+            context: context,
+            checked: someChecked ? null : allChecked,
+            onRowTap: null,
+            onCheckboxChanged: (bool? checked) => _handleSelectAll(checked, someChecked),
+            overlayColor: null,
+            checkboxTheme: headingCheckboxTheme,
+            tristate: true,
+            rowHeight: headingHeight) : const SizedBox();
 
       if (fixedCornerRows != null) {
         fixedCornerRows[0].children[0] = headingRow.children[0];

--- a/lib/src/data_table_2.dart
+++ b/lib/src/data_table_2.dart
@@ -1181,7 +1181,7 @@ class DataTable2 extends DataTable {
               checkboxTheme: headingCheckboxTheme,
               tristate: true,
               rowHeight: headingHeight)
-          : const SizedBox();
+          : SizedBox(height: headingHeight,);
 
       if (fixedCornerRows != null) {
         fixedCornerRows[0].children[0] = headingRow.children[0];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: data_table_2
 description: In-place substitute for Flutter's DataTable and PaginatedDataTable with fixed/sticky headers and few extra features
-version: 2.5.11
+version: 2.5.12
 homepage: https://github.com/maxim-saplin/data_table_2
 repository: https://github.com/maxim-saplin/data_table_2
 

--- a/test/custom_features_test.dart
+++ b/test/custom_features_test.dart
@@ -1981,7 +1981,46 @@ void main() {
     expect(d.length, kDesserts.length);
     expect((d.first.widget as Theme).child.runtimeType, Checkbox);
   });
+
+  testWidgets('DataTable2 heading checkbox', (WidgetTester tester) async {
+    final List<DataColumn2> columns = [
+      const DataColumn2(label: Text('Column1')),
+    ];
+    final List<DataRow2> rows = [
+      DataRow2(
+        onSelectChanged: (value) {},
+        cells: const [DataCell(Text('Content1'))],
+      ),
+    ];
+
+    // Check if heading checkbox is shown by default
+    await wrapWidgetSetSurf(
+        tester,
+        buildTable(
+          columns: columns,
+          rows: rows,
+        ));
+
+   await tester.pumpAndSettle();
+    expect(find.text('Column1'), findsOneWidget);
+    expect(find.byType(Checkbox), findsNWidgets(2));
+
+    // Check if heading checkbox is hided
+    await wrapWidgetSetSurf(
+        tester,
+        buildTable(
+          showHeadingCheckbox: false,
+          columns: columns,
+          rows: rows,
+        ));
+
+    await tester.pumpAndSettle();
+    expect(find.text('Column1'), findsOneWidget);
+    expect(find.byType(Checkbox), findsOneWidget);
+  });
 }
+
+
 
 Tripple<Size> _getColumnSizes(WidgetTester tester, bool header) {
   var s0 = tester.getSize(find.byType(DataTable2));

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -151,6 +151,7 @@ DataTable2 buildTable(
     Color? fixedCornerColor,
     Color? headingRowColor,
     BoxDecoration? headingRowDecoration,
+    bool showHeadingCheckbox = true,
     double? dividerThickness,
     bool showBottomBorder = false,
     TableBorder? border,
@@ -172,6 +173,7 @@ DataTable2 buildTable(
     sortArrowIcon: sortArrowIcon ?? Icons.arrow_upward,
     headingRowColor: MaterialStatePropertyAll(headingRowColor),
     headingRowDecoration: headingRowDecoration,
+    showHeadingCheckBox: showHeadingCheckbox,
     sortArrowAnimationDuration:
         sortArrowAnimationDuration ?? const Duration(milliseconds: 150),
     minWidth: minWidth,


### PR DESCRIPTION
A boolean option `showHeadingCheckBox` has been added to the data table configuration. This allows the user to choose whether to display the heading checkbox or not. In cases where the checkbox is not needed, a sized box takes its place instead.