### PR TITLE
Fix for #254, How to have selected rows on table create with AsyncDataTableSource?

### DIFF
--- a/lib/src/async_paginated_data_table_2.dart
+++ b/lib/src/async_paginated_data_table_2.dart
@@ -112,7 +112,7 @@ abstract class AsyncDataTableSource extends DataTableSource {
     } else {
       //none
       if (_rows[rowIndex].selected) {
-        _rows[rowIndex] = _clone(_rows[rowIndex], false);
+        _rows[rowIndex] = _clone(_rows[rowIndex], true);
       }
     }
   }


### PR DESCRIPTION
Fixes #254 
I just changed line 116 of AsyncDataTableSource setting the selected argument of the _clone method to true.
