### PR TITLE
Fix for #254, How to have selected rows on table create with AsyncDataTableSource

### DIFF
--- a/example/lib/data_sources.dart
+++ b/example/lib/data_sources.dart
@@ -212,7 +212,7 @@ class DessertDataSource extends DataTableSource {
 }
 
 /// Async datasource for AsynPaginatedDataTabke2 example. Based on AsyncDataTableSource which
-/// is an extension to FLutter's DataTableSource and aimed at solving
+/// is an extension to Flutter's DataTableSource and aimed at solving
 /// saync data fetching scenarious by paginated table (such as using Web API)
 class DessertDataSourceAsync extends AsyncDataTableSource {
   DessertDataSourceAsync() {


### PR DESCRIPTION
In _fixSelectedState we need to check for an entry in _selectionRowKeys for the SelectionState.none

In _fetchData we also need to ensure that  _selectionRowKeys  are maintained for the rows retreived from getRows