### PR TITLE
Added scrollPhysics to data_table_2

### DIFF
--- a/lib/src/data_table_2.dart
+++ b/lib/src/data_table_2.dart
@@ -176,6 +176,7 @@ class DataTable2 extends DataTable {
     this.horizontalScrollController,
     this.isVerticalScrollBarVisible,
     this.isHorizontalScrollBarVisible,
+    this.scrollPhysics,
     this.empty,
     this.border,
     this.smRatio = 0.67,
@@ -295,6 +296,10 @@ class DataTable2 extends DataTable {
 
   /// Determines whether the horizontal scroll bar is visible, for iOS takes value from scrollbarTheme when null
   final bool? isHorizontalScrollBarVisible;
+
+  /// Exposes scroll physics of the SingleChildScrollView that could makes data rows vertical scrollable even if the table view is not full.
+  /// Useful when used in conjunction with [RefreshIndicator]
+  final ScrollPhysics? scrollPhysics;
 
   /// Placeholder widget which is displayed whenever the data rows are empty.
   /// The widget will be displayed below column
@@ -1074,6 +1079,7 @@ class DataTable2 extends DataTable {
                             child: SingleChildScrollView(
                                 controller: coreVerticalController,
                                 scrollDirection: Axis.vertical,
+                                physics: scrollPhysics,
                                 child: SingleChildScrollView(
                                     controller: coreHorizontalController,
                                     scrollDirection: Axis.horizontal,


### PR DESCRIPTION
In this update, the scrollPhysics property has been added to the SingleChildScrollView in data_table_2.dart file. This new feature enhances the usability of the table view, by allowing data rows to be scrollable vertically even if the table view is not fully displayed. This addition can be particularly beneficial when used in combination with the RefreshIndicator.