### PR TITLE
Add ability to exclude DataRow2 checkboxes from keyboard focus.

### DIFF
--- a/lib/src/data_table_2.dart
+++ b/lib/src/data_table_2.dart
@@ -168,6 +168,7 @@ class DataTable2 extends DataTable {
     super.columnSpacing,
     this.showHeadingCheckBox = true,
     super.showCheckboxColumn = true,
+    this.skipDataRowCheckbox = false,
     super.showBottomBorder = false,
     super.dividerThickness,
     super.clipBehavior,
@@ -249,6 +250,11 @@ class DataTable2 extends DataTable {
   /// Alignment of the checkbox if it is displayed
   /// Defaults to the [Alignment.center]
   final Alignment checkboxAlignment;
+
+  /// If true, will skip the checkboxes within DataRows.
+  /// 
+  /// If [DataTable.showCheckboxColumn] is false, this does nothing.
+  final bool skipDataRowCheckbox;
 
   /// Whether to display heading checkbox or not if the checkbox column is present. Defaults to true.
   /// Also check [DataTable.showCheckboxColumn] for details
@@ -362,7 +368,8 @@ class DataTable2 extends DataTable {
       required WidgetStateProperty<Color?>? overlayColor,
       required CheckboxThemeData? checkboxTheme,
       required bool tristate,
-      required double? rowHeight}) {
+      required double? rowHeight,
+      required bool skipCheckbox}) {
     final DataTableThemeData dataTableTheme = DataTableTheme.of(context);
 
     final double effectiveHorizontalMargin = horizontalMargin ??
@@ -388,11 +395,15 @@ class DataTable2 extends DataTable {
       child: wrapInContainer(
         Theme(
             data: ThemeData(checkboxTheme: checkboxTheme),
+            child: ExcludeFocus(
+            excluding: skipCheckbox,
             child: Checkbox(
               value: checked,
               onChanged: onCheckboxChanged,
               tristate: tristate,
-            )),
+            ),
+          ),
+        ),
       ),
     );
     if (onRowTap != null) {
@@ -1179,7 +1190,8 @@ class DataTable2 extends DataTable {
               overlayColor: null,
               checkboxTheme: headingCheckboxTheme,
               tristate: true,
-              rowHeight: headingHeight)
+              rowHeight: headingHeight,
+              skipCheckbox: false)
           : SizedBox(
               height: headingHeight,
             );
@@ -1213,6 +1225,7 @@ class DataTable2 extends DataTable {
               }
             },
             onCheckboxChanged: row.onSelectChanged,
+            skipCheckbox: skipDataRowCheckbox,
             overlayColor: row.color ?? effectiveDataRowColor,
             checkboxTheme: datarowCheckboxTheme,
             tristate: false,

--- a/test/data_table_2_test.dart
+++ b/test/data_table_2_test.dart
@@ -88,7 +88,7 @@ void main() {
     expect(log, <String>['select-all: true']);
     log.clear();
 
-    // clicking on a cell empty space outside chekbox should still select the row
+    // clicking on a cell empty space outside checkbox should still select the row
     var c = tester.getCenter(find.byType(Checkbox).at(1));
     await tester.tapAt(Offset(c.dx - 16, c.dy - 16));
     expect(log, <String>['row-selected: Frozen yogurt']);
@@ -245,7 +245,7 @@ void main() {
     expect(log, <String>['select-all: true']);
     log.clear();
 
-    // clicking on a cell empty space outside chekbox should still select the row
+    // clicking on a cell empty space outside checkbox should still select the row
     var c = tester.getCenter(find.byType(Checkbox).at(1));
     await tester.tapAt(Offset(c.dx - 16, c.dy - 16));
     expect(log, <String>['row-selected: Frozen yogurt']);
@@ -2303,4 +2303,68 @@ void main() {
     expect(tableBorder?.bottom.width, null);
     expect(tableBorder?.top.color, null);
   });
+
+  final skipDataRowCheckboxVariants = ValueVariant({true, false});
+
+  testWidgets(
+    'DataTable row checkbox can be skipped',
+    (WidgetTester tester) async {
+      const List<DataColumn> columns = <DataColumn>[
+        DataColumn(label: Text('column1')),
+        DataColumn(label: Text('column2')),
+      ];
+
+      const List<DataCell> cells = <DataCell>[
+        DataCell(Text('cell1')),
+        DataCell(Text('cell2')),
+      ];
+
+      final List<DataRow> rows = <DataRow>[
+        DataRow(
+          onSelectChanged: (_) {},
+          cells: cells,
+        ),
+      ];
+
+      final skipDataRowCheckbox = skipDataRowCheckboxVariants.currentValue!;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: DataTable2(
+              border: TableBorder.all(width: 2, color: Colors.red),
+              columns: columns,
+              rows: rows,
+              showHeadingCheckBox: true,
+              showCheckboxColumn: true,
+              skipDataRowCheckbox: skipDataRowCheckbox,
+              onSelectAll: (_) {},
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await expectLater(find.byType(Checkbox), findsNWidgets(2));
+      final headerCheckbox = find.byType(Checkbox).first;
+      final rowCheckbox = find.byType(Checkbox).last;
+
+      final headerExcludeFocus = tester.widget<ExcludeFocus>(
+        find.ancestor(
+          of: headerCheckbox,
+          matching: find.byType(ExcludeFocus),
+        ),
+      );
+      final rowExcludeFocus = tester.widget<ExcludeFocus>(
+        find.ancestor(
+          of: rowCheckbox,
+          matching: find.byType(ExcludeFocus),
+        ),
+      );
+
+      expect(headerExcludeFocus.excluding, isFalse);
+      expect(rowExcludeFocus.excluding, equals(skipDataRowCheckbox));
+    },
+    variant: skipDataRowCheckboxVariants,
+  );
 }


### PR DESCRIPTION
#316

Add a new flag that allows header row checkboxes to skip keyboard focus traversal. This will improve the accessibility of our application when tapping a row vs selecting the checkbox does the same thing.