### PR TITLE
Fixed compile time error due to using removed "withValues" function in "Color" class.

### DIFF
--- a/lib/src/data_table_2.dart
+++ b/lib/src/data_table_2.dart
@@ -522,7 +522,7 @@ class DataTable2 extends DataTable {
       child: DefaultTextStyle(
         style: effectiveDataTextStyle.copyWith(
           color: placeholder
-              ? effectiveDataTextStyle.color!.withValues(alpha: 0.6)
+              ? effectiveDataTextStyle.color!.withOpacity( 0.6)
               : null,
         ),
         child: DropdownButtonHideUnderline(child: label),
@@ -593,7 +593,7 @@ class DataTable2 extends DataTable {
     final defaultRowColor = WidgetStateProperty.resolveWith(
       (Set<WidgetState> states) {
         if (states.contains(WidgetState.selected)) {
-          return theme.colorScheme.primary.withValues(alpha: 0.08);
+          return theme.colorScheme.primary.withOpacity(0.08);
         }
         return null;
       },


### PR DESCRIPTION
##What

Got the compile time error when running the example class. 
**"Error: the method 'withValues' isn't defined for the class 'Color'.**

##Fix

Updated "withValues" function with "withOpacity" in data_table2.dart. This was causing compile time errors while trying to run

