### PR TITLE
fix: use withOpacity instead withValues on Color

### DIFF
--- a/lib/src/data_table_2.dart
+++ b/lib/src/data_table_2.dart
@@ -522,7 +522,7 @@ class DataTable2 extends DataTable {
       child: DefaultTextStyle(
         style: effectiveDataTextStyle.copyWith(
           color: placeholder
-              ? effectiveDataTextStyle.color!.withValues(alpha: 0.6)
+              ? effectiveDataTextStyle.color!.withOpacity(0.6)
               : null,
         ),
         child: DropdownButtonHideUnderline(child: label),
@@ -593,7 +593,7 @@ class DataTable2 extends DataTable {
     final defaultRowColor = WidgetStateProperty.resolveWith(
       (Set<WidgetState> states) {
         if (states.contains(WidgetState.selected)) {
-          return theme.colorScheme.primary.withValues(alpha: 0.08);
+          return theme.colorScheme.primary.withOpacity(0.08);
         }
         return null;
       },


### PR DESCRIPTION
I'm using Flutter 3.24.5, there is an error when using the `data_table_2: ^2.5.18`. This error can be reproduce by running example proj.

And I change to use `withOpacity` which runs well. 

errorMsg: 
```
The method 'withValues' isn't defined for the type 'Color'.
```

I'm not sure it's the appropriate way to fix it, but it wors for me : )