### PR TITLE
feature: Add text optional in footer

### DIFF
--- a/example/lib/screens/paginated_data_table2.dart
+++ b/example/lib/screens/paginated_data_table2.dart
@@ -120,6 +120,7 @@ class PaginatedDataTable2DemoState extends State<PaginatedDataTable2Demo> {
   Widget build(BuildContext context) {
     return Stack(alignment: Alignment.bottomCenter, children: [
       PaginatedDataTable2(
+        rowsPerPageTitle: 'Items per page',
         // 100 Won't be shown since it is smaller than total records
         availableRowsPerPage: const [2, 5, 10, 30, 100],
         horizontalMargin: 20,

--- a/lib/src/paginated_data_table_2.dart
+++ b/lib/src/paginated_data_table_2.dart
@@ -216,6 +216,7 @@ class PaginatedDataTable2 extends StatefulWidget {
     this.headingRowDecoration,
     this.isVerticalScrollBarVisible,
     this.isHorizontalScrollBarVisible,
+    this.rowsPerPageTitle,
   })  : assert(actions == null || (header != null)),
         assert(columns.isNotEmpty),
         assert(sortColumnIndex == null ||
@@ -227,6 +228,9 @@ class PaginatedDataTable2 extends StatefulWidget {
           }
           return true;
         }());
+
+  /// Custom title for the "Rows per page" label in the paginator. If null, uses the default localization.
+  final String? rowsPerPageTitle;
 
   final bool wrapInCard;
 
@@ -838,7 +842,7 @@ class PaginatedDataTable2State extends State<PaginatedDataTable2> {
         footerWidgets.addAll(<Widget>[
           Container(width: 14.0),
           // to match trailing padding in case we overflow and end up scrolling
-          Text(localizations.rowsPerPageTitle),
+          Text(widget.rowsPerPageTitle ?? localizations.rowsPerPageTitle),
           ConstrainedBox(
             constraints: const BoxConstraints(
                 minWidth: 64.0), // 40.0 for the text, 24.0 for the icon


### PR DESCRIPTION
- feat: Allow customization of "Rows per page" title

Adds a rowsPerPageTitle property to PaginatedDataTable2 that allows overriding the default localized "Rows per page" text in the paginator.


![Screenshot 2025-07-04 at 4 58 09 PM](https://github.com/user-attachments/assets/1e253404-5ee9-4209-a72d-3b7237d5b988)
