### PR TITLE
Fix PaginatedDataTable2State.dispose() does not detach from its PaginatorController [fixes #373]

### DIFF
--- a/lib/src/paginated_data_table_2.dart
+++ b/lib/src/paginated_data_table_2.dart
@@ -579,6 +579,9 @@ class PaginatedDataTable2State extends State<PaginatedDataTable2> {
   @override
   void dispose() {
     widget.source.removeListener(_handleDataSourceChanged);
+    if (widget.controller?._state == this) {
+      widget.controller?._detach();
+    }
     super.dispose();
   }
 

--- a/test/custom_features_test.dart
+++ b/test/custom_features_test.dart
@@ -771,6 +771,28 @@ void main() {
       expect(controller.rowCount, 500);
     });
 
+    testWidgets('PaginatedDataTable2 detaches from paginator when destroyed', (WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 300));
+      var controller = PaginatorController();
+      await tester.pumpWidget(MaterialApp(
+          home: Material(
+              child: buildPaginatedTable(
+                  showPage: false,
+                  showGeneration: false,
+                  showPageSizeSelector: true,
+                  controller: controller))));
+      await tester.pumpAndSettle();
+
+      expect(controller.isAttached, true);
+
+      await tester.pumpWidget(MaterialApp(
+        home: Material()
+      ));
+      await tester.pumpAndSettle();
+
+      expect(controller.isAttached, false);
+    });
+
     testWidgets(
         'PaginatedDataTable2 initial sort indicator orientation not spoiled',
         (WidgetTester tester) async {


### PR DESCRIPTION
Per #373:

PaginatedDataTable2State.dispose() does not call `controller._detach()` in its `dispose()` method:

https://github.com/maxim-saplin/data_table_2/blob/879f9baa25751dd928d2cc8511d95d519cd551bb/lib/src/paginated_data_table_2.dart#L580-L583

Right now, a consumer that passes a PaginatedController into a PaginatedDataTable2 is unable to use `PaginatorController.isAttached` to  tell whether they can safely call any of the methods on the controller.

This PR fixes this.