### PR TITLE
feature request: Add more customization to PaginatedDataTable2 paginator footer

### DIFF
--- a/lib/src/paginated_data_table_2.dart
+++ b/lib/src/paginated_data_table_2.dart
@@ -221,6 +221,7 @@ class PaginatedDataTable2 extends StatefulWidget {
     this.firstPageIcon,
     this.lastPageIcon,
     this.iconSize,
+    this.iconOpacity = 0.54,
     this.paginatorIconDisabledColor,
     this.paginatorIconEnabledColor,
     this.footerTextStyle,
@@ -545,6 +546,9 @@ class PaginatedDataTable2 extends StatefulWidget {
 
   /// The size of the paginator's arrow icons.
   final double? iconSize;
+
+  /// Opacity of the paginator's arrow icons. Defaults to 0.54
+  final double iconOpacity;
 
   /// Custom color for any of the paginator's arrow icons when disabled.
   final Color? paginatorIconDisabledColor;
@@ -969,7 +973,7 @@ class PaginatedDataTable2State extends State<PaginatedDataTable2> {
     return DefaultTextStyle(
       style: widget.footerTextStyle ?? footerTextStyle!,
       child: IconTheme.merge(
-        data: const IconThemeData(opacity: 0.54),
+        data: IconThemeData(opacity: widget.iconOpacity),
         child: Container(
           height: widget.footerHeight,
 	  width: double.infinity,

--- a/lib/src/paginated_data_table_2.dart
+++ b/lib/src/paginated_data_table_2.dart
@@ -220,9 +220,11 @@ class PaginatedDataTable2 extends StatefulWidget {
     this.previousPageIcon,
     this.firstPageIcon,
     this.lastPageIcon,
+    this.iconSize,
     this.paginatorIconDisabledColor,
     this.paginatorIconEnabledColor,
     this.footerTextStyle,
+    this.footerDecoration,
   })  : assert(actions == null || (header != null)),
         assert(columns.isNotEmpty),
         assert(sortColumnIndex == null ||
@@ -540,6 +542,9 @@ class PaginatedDataTable2 extends StatefulWidget {
   /// Icon for the last page button. If null, [Icons.skip_next] is used.
   final Icon? lastPageIcon;
 
+  /// The size of the paginator's arrow icons.
+  final double? iconSize;
+
   /// Custom color for any of the paginator's arrow icons when disabled.
   final Color? paginatorIconDisabledColor;
 
@@ -548,6 +553,9 @@ class PaginatedDataTable2 extends StatefulWidget {
 
   /// The style to use for the footer text.
   final TextStyle? footerTextStyle;
+
+  /// The decoration to use for the footer.
+  final BoxDecoration? footerDecoration;
 
   @override
   PaginatedDataTable2State createState() => PaginatedDataTable2State();
@@ -911,6 +919,7 @@ class PaginatedDataTable2State extends State<PaginatedDataTable2> {
       if (widget.showFirstLastButtons)
         IconButton(
           icon: widget.firstPageIcon ?? const Icon(Icons.skip_previous),
+          iconSize: widget.iconSize,
           color: _firstRowIndex <= 0
 		     ? widget.paginatorIconDisabledColor
 		     : widget.paginatorIconEnabledColor,
@@ -920,6 +929,7 @@ class PaginatedDataTable2State extends State<PaginatedDataTable2> {
         ),
       IconButton(
         icon: widget.previousPageIcon ?? const Icon(Icons.chevron_left),
+        iconSize: widget.iconSize,
         color: _firstRowIndex <= 0
 		   ? widget.paginatorIconDisabledColor
 		   : widget.paginatorIconEnabledColor,
@@ -930,6 +940,7 @@ class PaginatedDataTable2State extends State<PaginatedDataTable2> {
       Container(width: 24.0),
       IconButton(
         icon: widget.nextPageIcon ?? const Icon(Icons.chevron_right),
+        iconSize: widget.iconSize,
         color: _isNextPageUnavailable()
 		   ? widget.paginatorIconDisabledColor
 		   : widget.paginatorIconEnabledColor,
@@ -940,6 +951,7 @@ class PaginatedDataTable2State extends State<PaginatedDataTable2> {
       if (widget.showFirstLastButtons)
         IconButton(
           icon: widget.lastPageIcon ?? const Icon(Icons.skip_next),
+          iconSize: widget.iconSize,
           color: _isNextPageUnavailable()
 		     ? widget.paginatorIconDisabledColor
 		     : widget.paginatorIconEnabledColor,
@@ -954,8 +966,10 @@ class PaginatedDataTable2State extends State<PaginatedDataTable2> {
       style: widget.footerTextStyle ?? footerTextStyle!,
       child: IconTheme.merge(
         data: const IconThemeData(opacity: 0.54),
-        child: SizedBox(
+        child: Container(
           height: 56.0,
+	  width: double.infinity,
+	  decoration: widget.footerDecoration,
           child: SingleChildScrollView(
             dragStartBehavior: widget.dragStartBehavior,
             scrollDirection: Axis.horizontal,

--- a/lib/src/paginated_data_table_2.dart
+++ b/lib/src/paginated_data_table_2.dart
@@ -216,6 +216,13 @@ class PaginatedDataTable2 extends StatefulWidget {
     this.headingRowDecoration,
     this.isVerticalScrollBarVisible,
     this.isHorizontalScrollBarVisible,
+    this.nextPageIcon,
+    this.previousPageIcon,
+    this.firstPageIcon,
+    this.lastPageIcon,
+    this.paginatorIconDisabledColor,
+    this.paginatorIconEnabledColor,
+    this.footerTextStyle,
   })  : assert(actions == null || (header != null)),
         assert(columns.isNotEmpty),
         assert(sortColumnIndex == null ||
@@ -520,6 +527,27 @@ class PaginatedDataTable2 extends StatefulWidget {
 
   /// Determines whether the horizontal scroll bar is visible, for iOS takes value from scrollbarTheme when null
   final bool? isHorizontalScrollBarVisible;
+
+  /// Icon for the next page button. If null, [Icons.chevron_right] is used.
+  final Icon? nextPageIcon;
+
+  /// Icon for the previous page button. If null, [Icons.chevron_left] is used.
+  final Icon? previousPageIcon;
+
+  /// Icon for the first page button. If null, [Icons.skip_previous] is used.
+  final Icon? firstPageIcon;
+
+  /// Icon for the last page button. If null, [Icons.skip_next] is used.
+  final Icon? lastPageIcon;
+
+  /// Custom color for any of the paginator's arrow icons when disabled.
+  final Color? paginatorIconDisabledColor;
+
+  /// Custom color for any of the paginator's arrow icons when enabled.
+  final Color? paginatorIconEnabledColor;
+
+  /// The style to use for the footer text.
+  final TextStyle? footerTextStyle;
 
   @override
   PaginatedDataTable2State createState() => PaginatedDataTable2State();
@@ -882,27 +910,39 @@ class PaginatedDataTable2State extends State<PaginatedDataTable2> {
       Container(width: 32.0),
       if (widget.showFirstLastButtons)
         IconButton(
-          icon: const Icon(Icons.skip_previous),
-          padding: EdgeInsets.zero,
+          icon: widget.firstPageIcon ?? const Icon(Icons.skip_previous),
+          color: _firstRowIndex <= 0
+		     ? widget.paginatorIconDisabledColor
+		     : widget.paginatorIconEnabledColor,
+	  padding: EdgeInsets.zero,
           tooltip: localizations.firstPageTooltip,
           onPressed: _firstRowIndex <= 0 ? null : _handleFirst,
         ),
       IconButton(
-        icon: const Icon(Icons.chevron_left),
+        icon: widget.previousPageIcon ?? const Icon(Icons.chevron_left),
+        color: _firstRowIndex <= 0
+		   ? widget.paginatorIconDisabledColor
+		   : widget.paginatorIconEnabledColor,
         padding: EdgeInsets.zero,
         tooltip: localizations.previousPageTooltip,
         onPressed: _firstRowIndex <= 0 ? null : _handlePrevious,
       ),
       Container(width: 24.0),
       IconButton(
-        icon: const Icon(Icons.chevron_right),
-        padding: EdgeInsets.zero,
+        icon: widget.nextPageIcon ?? const Icon(Icons.chevron_right),
+        color: _isNextPageUnavailable()
+		   ? widget.paginatorIconDisabledColor
+		   : widget.paginatorIconEnabledColor,
+	padding: EdgeInsets.zero,
         tooltip: localizations.nextPageTooltip,
         onPressed: _isNextPageUnavailable() ? null : _handleNext,
       ),
       if (widget.showFirstLastButtons)
         IconButton(
-          icon: const Icon(Icons.skip_next),
+          icon: widget.lastPageIcon ?? const Icon(Icons.skip_next),
+          color: _isNextPageUnavailable()
+		     ? widget.paginatorIconDisabledColor
+		     : widget.paginatorIconEnabledColor,
           padding: EdgeInsets.zero,
           tooltip: localizations.lastPageTooltip,
           onPressed: _isNextPageUnavailable() ? null : _handleLast,
@@ -911,7 +951,7 @@ class PaginatedDataTable2State extends State<PaginatedDataTable2> {
     ]);
 
     return DefaultTextStyle(
-      style: footerTextStyle!,
+      style: widget.footerTextStyle ?? footerTextStyle!,
       child: IconTheme.merge(
         data: const IconThemeData(opacity: 0.54),
         child: SizedBox(

--- a/lib/src/paginated_data_table_2.dart
+++ b/lib/src/paginated_data_table_2.dart
@@ -225,6 +225,7 @@ class PaginatedDataTable2 extends StatefulWidget {
     this.paginatorIconEnabledColor,
     this.footerTextStyle,
     this.footerDecoration,
+    this.footerHeight = 56.0,
   })  : assert(actions == null || (header != null)),
         assert(columns.isNotEmpty),
         assert(sortColumnIndex == null ||
@@ -556,6 +557,9 @@ class PaginatedDataTable2 extends StatefulWidget {
 
   /// The decoration to use for the footer.
   final BoxDecoration? footerDecoration;
+
+  /// The height of the footer.
+  final double footerHeight;
 
   @override
   PaginatedDataTable2State createState() => PaginatedDataTable2State();
@@ -967,7 +971,7 @@ class PaginatedDataTable2State extends State<PaginatedDataTable2> {
       child: IconTheme.merge(
         data: const IconThemeData(opacity: 0.54),
         child: Container(
-          height: 56.0,
+          height: widget.footerHeight,
 	  width: double.infinity,
 	  decoration: widget.footerDecoration,
           child: SingleChildScrollView(


### PR DESCRIPTION
Overall, improves the flexibility of the paginator's customization.

- Provides firstPageIcon, previousPageIcon, nextPageIcon, and lastPageIcon properties to customize paginator navigation icons.
- Provides iconSize and iconOpacity to customize pagination navigation icon size and opacity.
- Introduces paginatorIconDisabledColor and paginatorIconEnabledColor to customize paginator icon color.
- Introduces footerTextStyle to customize the text style of the row numbers.
- Introduces footerDecoration for adding a decoration on the pagination footer.
- Introduces footerHeight to customize the footer height.

Can be combined with [#351](https://github.com/maxim-saplin/data_table_2/pull/351) if needed.