### PR TITLE
fix: Update tests affected by new StretchingOverscrollIndicator behavior

### DIFF
--- a/test/async_paginated_data_table2_test.dart
+++ b/test/async_paginated_data_table2_test.dart
@@ -381,7 +381,7 @@ void main() {
       Offset(50.0, tester.getTopLeft(find.text('Rows per page:')).dy),
       const Offset(1000.0, 0.0),
     );
-    await tester.pump();
+    await tester.pumpAndSettle();
     expect(find.text('Rows per page:'), findsOneWidget);
     expect(tester.getTopLeft(find.text('Rows per page:')).dx,
         18.0); // 14 padding in the footer row, 4 padding from the card

--- a/test/paginated_data_table2_data_column2_test.dart
+++ b/test/paginated_data_table2_data_column2_test.dart
@@ -349,7 +349,7 @@ void main() {
       Offset(50.0, tester.getTopLeft(find.text('Rows per page:')).dy),
       const Offset(1000.0, 0.0),
     );
-    await tester.pump();
+    await tester.pumpAndSettle();
     expect(find.text('Rows per page:'), findsOneWidget);
     expect(tester.getTopLeft(find.text('Rows per page:')).dx,
         18.0); // 14 padding in the footer row, 4 padding from the card

--- a/test/paginated_data_table2_test.dart
+++ b/test/paginated_data_table2_test.dart
@@ -402,7 +402,7 @@ void main() {
       Offset(50.0, tester.getTopLeft(find.text('Rows per page:')).dy),
       const Offset(1000.0, 0.0),
     );
-    await tester.pump();
+    await tester.pumpAndSettle();
     expect(find.text('Rows per page:'), findsOneWidget);
     expect(tester.getTopLeft(find.text('Rows per page:')).dx,
         18.0); // 14 padding in the footer row, 4 padding from the card


### PR DESCRIPTION
This PR fixes failing tests in the data_table_2 package caused by the updated StretchingOverscrollIndicator behavior ported from Android 12. 

For more details, please refer to PR: https://github.com/flutter/flutter/pull/173849