### PR TITLE
Fix listener lifecycle  in custom_pager.dart example

### DIFF
--- a/example/lib/custom_pager.dart
+++ b/example/lib/custom_pager.dart
@@ -58,12 +58,20 @@ class CustomPager extends StatefulWidget {
 class CustomPagerState extends State<CustomPager> {
   static const List<int> _availableSizes = [3, 5, 10, 20];
 
+  void update() {
+    setState(() {});
+  }
+
   @override
   void initState() {
     super.initState();
-    widget.controller.addListener(() {
-      setState(() {});
-    });
+    widget._controller.addListener(update);
+  }
+
+  @override
+  void dispose() {
+    widget._controller.removeListener(update);
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION
Fix the `CustomPagerState` in the same way that is done for `PageNumberState`. Removing listener on dispose.