### PR TITLE
Add support for customizable paginator alignment in PaginatedDataTable2

### DIFF
--- a/example/lib/screens/paginated_data_table2.dart
+++ b/example/lib/screens/paginated_data_table2.dart
@@ -199,6 +199,7 @@ class PaginatedDataTable2DemoState extends State<PaginatedDataTable2Demo> {
           realTime: true,
           widgetColor: Theme.of(context).primaryColor,
         ),
+        paginatorAlignment: MainAxisAlignment.start,
       ),
       if (getCurrentRouteOption(context) == custPager)
         Positioned(bottom: 16, child: CustomPager(_controller!))

--- a/lib/src/async_paginated_data_table_2.dart
+++ b/lib/src/async_paginated_data_table_2.dart
@@ -366,6 +366,7 @@ class AsyncPaginatedDataTable2 extends PaginatedDataTable2 {
     super.minWidth,
     super.fit = FlexFit.tight,
     super.hidePaginator = false,
+    super.paginatorAlignment,
     super.controller,
     super.scrollController,
     super.horizontalScrollController,

--- a/lib/src/paginated_data_table_2.dart
+++ b/lib/src/paginated_data_table_2.dart
@@ -205,6 +205,7 @@ class PaginatedDataTable2 extends StatefulWidget {
     this.minWidth,
     this.fit = FlexFit.tight,
     this.hidePaginator = false,
+    this.paginatorAlignment = MainAxisAlignment.end,
     this.controller,
     this.scrollController,
     this.horizontalScrollController,
@@ -505,6 +506,10 @@ class PaginatedDataTable2 extends StatefulWidget {
   /// Hides the paginator at the bottom. Can be useful in case you decide create
   /// your own paginator and control the widget via [PaginatedDataTable2.controller]
   final bool hidePaginator;
+
+  /// Alignment of footer (paginator)
+  /// start = left, center = center, end = right (default Material behavior)
+  final MainAxisAlignment paginatorAlignment;
 
   /// Used to comntrol widget's state externally and trigger actions. See
   /// [PaginatorController]
@@ -921,13 +926,35 @@ class PaginatedDataTable2State extends State<PaginatedDataTable2> {
         data: const IconThemeData(opacity: 0.54),
         child: SizedBox(
           height: 56.0,
-          child: SingleChildScrollView(
-            dragStartBehavior: widget.dragStartBehavior,
-            scrollDirection: Axis.horizontal,
-            reverse: true,
-            child: Row(
-              children: footerWidgets,
-            ),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              return SingleChildScrollView(
+                dragStartBehavior: widget.dragStartBehavior,
+                scrollDirection: Axis.horizontal,
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(
+                    minWidth: constraints.maxWidth,
+                  ),
+                  child: Align(
+                    alignment: () {
+                      switch (widget.paginatorAlignment) {
+                        case MainAxisAlignment.start:
+                          return Alignment.centerLeft;
+                        case MainAxisAlignment.center:
+                          return Alignment.center;
+                        case MainAxisAlignment.end:
+                        default:
+                          return Alignment.centerRight;
+                      }
+                    }(),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: footerWidgets,
+                    ),
+                  ),
+                ),
+              );
+            },
           ),
         ),
       ),


### PR DESCRIPTION

## Footer alignment support for `PaginatedDataTable2`

### Summary

Adds a new `footerAlignment` parameter to control the horizontal alignment of the paginator (footer): start, center, or end. Default is `MainAxisAlignment.end`.

### Motivation

Previously, the footer was always aligned to the right due to internal scroll layout. This change allows flexible alignment while preserving horizontal scrolling on overflow.

### Implementation

* Uses `LayoutBuilder` + `ConstrainedBox(minWidth: constraints.maxWidth)`
* `Align` for left/center/right positioning
* `SingleChildScrollView` for horizontal scroll if content overflows

### Usage

```dart
PaginatedDataTable2(
  footerAlignment: MainAxisAlignment.center, // start | center | end
)
```

### Backward compatibility

* Default behavior unchanged
* No breaking changes


<img width="1152" height="951" alt="image" src="https://github.com/user-attachments/assets/f8316525-0e32-4804-8157-14687963dc96" />
